### PR TITLE
Improve voice assets insertion andn CI/CD actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ token.pickle
 
 # Log files
 *.log
+assets/*

--- a/classes/PomodoroVoiceManager.py
+++ b/classes/PomodoroVoiceManager.py
@@ -26,12 +26,12 @@ class PomodoroVoiceManager:
     def _resolve_audio_path(mode: str) -> Optional[Path]:
         normalized_mode = mode.lower().strip()
         key = "POMODORO_AUDIO_PATH"
+        default_path = Path("assets/focus.mp3")
         if normalized_mode == "break":
             key = "POMODORO_BREAK_AUDIO_PATH"
+            default_path = Path("assets/break.mp3")
         raw_path = (env.get(key) or "").strip()
-        if not raw_path:
-            return None
-        path = Path(raw_path)
+        path = Path(raw_path) if raw_path else default_path
         if not path.is_absolute():
             path = Path.cwd() / path
         return path
@@ -71,12 +71,7 @@ class PomodoroVoiceManager:
         normalized_mode = mode.lower().strip()
         audio_path = cls._resolve_audio_path(normalized_mode)
         if audio_path is None:
-            if normalized_mode == "break":
-                return (
-                    "POMODORO_BREAK_AUDIO_PATH is not set, so I couldn't start break "
-                    "audio."
-                )
-            return "POMODORO_AUDIO_PATH is not set, so I couldn't start focus audio."
+            return "Pomodoro audio path could not be resolved."
         if not audio_path.exists() or not audio_path.is_file():
             return f"Audio file not found at `{audio_path}`."
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,7 @@ services:
         source: ./.env
         target: /app/.env
         read_only: true
+      - type: bind
+        source: ${POMODORO_VOICE_ASSETS}
+        target: /app/assets
+        read_only: true


### PR DESCRIPTION
- voice assets are no longer provide via `.env` file, but rather expected to be located inside the `assets/` folder
- bindings are provided in the `docker-compose.yml` file