### PR TITLE
Introduce restart safe View buttons

### DIFF
--- a/classes/PomodoroFunctions.py
+++ b/classes/PomodoroFunctions.py
@@ -44,6 +44,15 @@ class PomodoroResumeResult:
     duration_minutes: Optional[int] = None
 
 
+@dataclass
+class PomodoroState:
+    exists: bool
+    mode: str = "focus"
+    end_time: Optional[datetime.datetime] = None
+    duration_minutes: Optional[int] = None
+    is_paused: bool = False
+
+
 class PomodoroFunctions:
     @staticmethod
     def _normalize_datetime(
@@ -634,4 +643,77 @@ class PomodoroFunctions:
             end_time=new_end_time,
             duration_minutes=new_duration,
             mode=mode,
+        )
+
+    @staticmethod
+    async def get_user_pomodoro_state(
+        interaction: discord.Interaction,
+    ) -> PomodoroState:
+        manager = DailyJobManager()
+
+        try:
+            jobs = await PomodoroFunctions._list_scope_jobs(manager, interaction)
+        except Exception:
+            return PomodoroState(exists=False)
+
+        user_id = str(interaction.user.id)
+        user_jobs = [
+            job
+            for job in jobs
+            if job.type == "pomodoro" and str(job.data.get("user")) == user_id
+        ]
+        if not user_jobs:
+            return PomodoroState(exists=False)
+
+        running_job, running_end_time = PomodoroFunctions._select_user_job_by_pause_state(
+            user_jobs,
+            paused=False,
+        )
+        if running_job is not None and running_end_time is not None:
+            data = running_job.data or {}
+            mode = str(data.get("mode", "focus")).strip().lower()
+            if mode not in ("focus", "break"):
+                mode = "focus"
+            duration_minutes = PomodoroFunctions._safe_int(
+                data.get("duration"),
+                default=0,
+            )
+            return PomodoroState(
+                exists=True,
+                mode=mode,
+                end_time=running_end_time,
+                duration_minutes=duration_minutes or None,
+                is_paused=False,
+            )
+
+        paused_job, _ = PomodoroFunctions._select_user_job_by_pause_state(
+            user_jobs,
+            paused=True,
+        )
+        if paused_job is None:
+            return PomodoroState(exists=False)
+
+        paused_data = paused_job.data or {}
+        paused_mode = str(paused_data.get("mode", "focus")).strip().lower()
+        if paused_mode not in ("focus", "break"):
+            paused_mode = "focus"
+
+        remaining_seconds = PomodoroFunctions._safe_int(
+            paused_data.get("paused_remaining_seconds"),
+            default=0,
+        )
+        if remaining_seconds <= 0:
+            fallback_minutes = PomodoroFunctions._safe_int(
+                paused_data.get("duration"),
+                default=0,
+            )
+            remaining_seconds = max(0, fallback_minutes * 60)
+
+        duration_minutes = max(1, math.ceil(remaining_seconds / 60)) if remaining_seconds > 0 else None
+        return PomodoroState(
+            exists=True,
+            mode=paused_mode,
+            end_time=None,
+            duration_minutes=duration_minutes,
+            is_paused=True,
         )

--- a/classes/TogglFunctions.py
+++ b/classes/TogglFunctions.py
@@ -201,6 +201,20 @@ class TogglFunctions:
         )
         return res.json()
 
+    def getTimeEntry(self, workspace_id, time_entry_id):
+        res = self._session().get(
+            f"https://api.track.toggl.com/api/v9/workspaces/{workspace_id}/time_entries/{time_entry_id}",
+            headers={"Content-Type": "application/json"},
+            auth=self.auth,
+        )
+        if res.status_code == 404:
+            return None
+        try:
+            payload = res.json()
+        except ValueError:
+            return None
+        return payload if isinstance(payload, dict) else None
+
     def updateTimeEntry(
         self,
         workspace_id,

--- a/cogs/ReminderCog.py
+++ b/cogs/ReminderCog.py
@@ -552,6 +552,7 @@ class ReminderCog(commands.Cog):
             sort=sort_value,
             response_ephemeral=ephemeral,
         )
+        await view.ensure_session()
         message = await interaction.followup.send(
             ephemeral=ephemeral,
             view=view,

--- a/cogs/TodoCog.py
+++ b/cogs/TodoCog.py
@@ -623,6 +623,7 @@ class TodoCog(commands.Cog):
             view_scope="list",
             guild_id=interaction.guild_id,
         )
+        await view.ensure_session()
         await interaction.followup.send(
             ephemeral=ephemeral,
             view=view,
@@ -939,6 +940,7 @@ class TodoCog(commands.Cog):
             view_scope="overview",
             guild_id=interaction.guild_id,
         )
+        await view.ensure_session()
         await interaction.followup.send(
             ephemeral=ephemeral,
             view=view,

--- a/cogs/TodoCog.py
+++ b/cogs/TodoCog.py
@@ -844,6 +844,7 @@ class TodoCog(commands.Cog):
             channel_name=getattr(interaction.channel, "name", None),
             user_id=interaction.user.id,
         )
+        await directory_view.ensure_session()
         try:
             await interaction.edit_original_response(
                 view=directory_view,

--- a/embeds/HabitEmbeds.py
+++ b/embeds/HabitEmbeds.py
@@ -3,8 +3,6 @@ from typing import Optional, Dict, Any
 
 import discord
 
-from views.HabitActionView import HabitActionView
-
 
 class HabitEmbeds:
     _PROGRESS_EMOJI = {
@@ -104,6 +102,8 @@ class HabitEmbeds:
 
     @staticmethod
     def habit_reminder_payload(habit: Dict[str, Any]) -> dict:
+        from views.HabitActionView import HabitActionView
+
         name = str(habit.get("name") or "Habit")
         description = habit.get("description")
         user_id = habit.get("user_id")

--- a/embeds/TodoEmbeds.py
+++ b/embeds/TodoEmbeds.py
@@ -8,6 +8,7 @@ import discord
 from classes.TodoFunctions import TodoFunctions
 from classes.UserSettingsFunctions import UserSettingsFunctions
 from services.due_datetime import DueDateService
+from services import todo_list_item_sessions
 from services.error_reporting import (
     UserVisibleError,
     ValidationError,
@@ -503,7 +504,7 @@ class TodoItemEditModal(discord.ui.Modal):
         else:
             try:
                 await self.parent_view._reload_items()
-                self.parent_view._build()
+                await self.parent_view.ensure_session()
                 if self.source_message is not None:
                     await self._edit_source_payload(
                         view=self.parent_view,
@@ -763,7 +764,7 @@ class TodoItemCreateModal(discord.ui.Modal):
                     self.parent_view.page = self.parent_view.total_pages
                 else:
                     self.parent_view.page = 1
-            self.parent_view._build()
+            await self.parent_view.ensure_session()
             if self.source_message is not None:
                 await self.source_message.edit(
                     view=self.parent_view,
@@ -1042,7 +1043,7 @@ class TodoListOptionsModal(discord.ui.Modal):
 
         try:
             await self.parent_view._reload_items()
-            self.parent_view._build()
+            await self.parent_view.ensure_session()
         except Exception as exc:
             await handle_interaction_error(
                 interaction,
@@ -1154,8 +1155,11 @@ class TodoListItemsView(discord.ui.View):
         guild_id: Optional[int] = None,
         page: int = 1,
         page_size: int = 5,
+        search_query: str = "",
+        session_id: Optional[str] = None,
+        timeout: float | None = None,
     ) -> None:
-        super().__init__(timeout=300)
+        super().__init__(timeout=timeout)
         self.todo_list = todo_list
         self._all_items = items
         self.items: List[Dict[str, Any]] = []
@@ -1186,13 +1190,105 @@ class TodoListItemsView(discord.ui.View):
         self.user_id = user_id
         self.view_scope = view_scope
         self.guild_id = guild_id
-        self.search_query = ""
+        self.search_query = self.normalize_search_query(search_query)
         self.assignee_filter_label = self._assignee_filter_summary_label()
         self.page_size = max(1, min(page_size, 5))
         self.total_pages = 1
         self.page = max(1, page)
+        self.session_id = str(session_id or "").strip() or None
         self._apply_filters()
+        if self.session_id is not None:
+            self._build()
+
+    @classmethod
+    async def from_session(
+        cls,
+        interaction: discord.Interaction,
+        session_id: str,
+    ) -> Optional["TodoListItemsView"]:
+        session = await asyncio.to_thread(
+            todo_list_item_sessions.get_session,
+            session_id,
+        )
+        if session is None:
+            return None
+
+        todo_list_id = str(session.get("todo_list_id") or "").strip()
+        todo_list = {
+            "_id": todo_list_id or None,
+            "name": str(session.get("todo_list_name") or "").strip(),
+            "scope": str(session.get("todo_scope") or "channel").strip(),
+            "channel_id": session.get("todo_channel_id"),
+            "user_id": session.get("todo_user_id"),
+            "guild_id": session.get("guild_id"),
+        }
+        if todo_list_id:
+            refreshed_list = await asyncio.to_thread(
+                TodoFunctions.fetch_todo_list_by_id,
+                todo_list_id,
+            )
+            if refreshed_list is not None:
+                todo_list = refreshed_list
+
+        view = cls(
+            todo_list=todo_list,
+            items=[],
+            sort=str(session.get("sort") or "ascending").strip(),
+            status_filter=str(session.get("status_filter") or "all").strip(),
+            assignee_filter_ids=list(session.get("assignee_filter_ids") or []),
+            assignee_filter_unassigned=bool(
+                session.get("assignee_filter_unassigned", False)
+            ),
+            user_id=session.get("user_id"),
+            view_scope=str(session.get("view_scope") or "list").strip(),
+            guild_id=session.get("guild_id"),
+            page=max(1, int(session.get("page") or 1)),
+            page_size=max(1, int(session.get("page_size") or 5)),
+            search_query=str(session.get("search_query") or ""),
+            session_id=str(session.get("session_id") or session_id).strip(),
+        )
+        await view._reload_items()
+        await view.ensure_session()
+        return view
+
+    def session_state(self) -> dict:
+        return {
+            "todo_list_id": str(self.todo_list.get("_id") or "").strip(),
+            "todo_list_name": TodoFunctions.display_list_name(self.todo_list, "List"),
+            "todo_scope": str(self.todo_list.get("scope") or "channel"),
+            "todo_channel_id": self.todo_list.get("channel_id"),
+            "todo_user_id": self.todo_list.get("user_id"),
+            "sort": self.sort,
+            "status_filter": self.status_filter,
+            "assignee_filter_ids": self.assignee_filter_ids,
+            "assignee_filter_unassigned": self.assignee_filter_unassigned,
+            "user_id": self.user_id,
+            "view_scope": self.view_scope,
+            "guild_id": self.guild_id,
+            "page": self.page,
+            "page_size": self.page_size,
+            "search_query": self.search_query,
+        }
+
+    async def ensure_session(self) -> str:
+        if self.session_id is None:
+            self.session_id = await asyncio.to_thread(
+                todo_list_item_sessions.create_session,
+                self.session_state(),
+            )
+        else:
+            await self.save_session()
         self._build()
+        return self.session_id
+
+    async def save_session(self) -> None:
+        if self.session_id is None:
+            return
+        await asyncio.to_thread(
+            todo_list_item_sessions.save_session,
+            self.session_id,
+            self.session_state(),
+        )
 
     def _page_slice(self) -> List[Dict[str, Any]]:
         start = (self.page - 1) * self.page_size
@@ -1529,6 +1625,8 @@ class TodoListItemsView(discord.ui.View):
             return
 
     async def _safe_refresh_message(self, interaction: discord.Interaction) -> bool:
+        self._build()
+        await self.save_session()
         try:
             if interaction.response.is_done():
                 await interaction.edit_original_response(view=self, **self.payload())
@@ -1855,95 +1953,52 @@ class TodoListItemsView(discord.ui.View):
 
     def _build(self) -> None:
         self.clear_items()
+        if self.session_id is None:
+            return
+
+        from views.todo_list_items_dynamic_items import (
+            TodoListItemInfoButton,
+            TodoListItemsAddButton,
+            TodoListItemsNextButton,
+            TodoListItemsOptionsButton,
+            TodoListItemsPrevButton,
+        )
 
         for slot_index in range(self.page_size):
-            display_index = slot_index + 1
             item = self._page_item(slot_index)
-            item_id = str((item or {}).get("_id") or "")
             has_item = item is not None
-
-            info_button = discord.ui.Button(
-                label=str(display_index),
-                style=discord.ButtonStyle.secondary,
-                custom_id=f"todo_item_info:{item_id or display_index}",
-                row=0,
-                disabled=not has_item,
+            self.add_item(
+                TodoListItemInfoButton(
+                    self.session_id,
+                    slot_index,
+                    disabled=not has_item,
+                )
             )
 
-            async def _info_callback(
-                interaction: discord.Interaction,
-                item_data: Optional[Dict[str, Any]] = item,
-            ) -> None:
-                await self._open_item_details(interaction, item_data)
-
-            info_button.callback = _info_callback
-            self.add_item(info_button)
-
-        prev_button = discord.ui.Button(
-            style=discord.ButtonStyle.secondary,
-            emoji="◀️",
-            disabled=self.page <= 1,
-            row=1,
-        )
-        add_button = discord.ui.Button(
-            style=discord.ButtonStyle.success,
-            emoji="➕",
-            row=1,
-            disabled=(self.view_scope != "list") or (self.todo_list.get("_id") is None),
-        )
-        next_button = discord.ui.Button(
-            style=discord.ButtonStyle.secondary,
-            emoji="▶️",
-            disabled=self.page >= self.total_pages,
-            row=1,
-        )
-        options_button = discord.ui.Button(
-            style=(
-                discord.ButtonStyle.success
-                if self._has_active_list_options()
-                else discord.ButtonStyle.secondary
-            ),
-            emoji="🔎",
-            row=1,
-        )
-
-        async def _prev_callback(interaction: discord.Interaction) -> None:
-            if self.page <= 1:
-                await interaction.response.defer(ephemeral=True)
-                return
-            self.page -= 1
-            self._build()
-            await self._safe_refresh_message(interaction)
-
-        async def _next_callback(interaction: discord.Interaction) -> None:
-            if self.page >= self.total_pages:
-                await interaction.response.defer(ephemeral=True)
-                return
-            self.page += 1
-            self._build()
-            await self._safe_refresh_message(interaction)
-
-        async def _add_callback(interaction: discord.Interaction) -> None:
-            await self.open_create_modal(
-                interaction,
-                source_message=interaction.message,
+        self.add_item(
+            TodoListItemsPrevButton(
+                self.session_id,
+                disabled=self.page <= 1,
             )
-
-        async def _options_callback(interaction: discord.Interaction) -> None:
-            await self.open_options_modal(
-                interaction,
-                source_message=interaction.message,
+        )
+        self.add_item(
+            TodoListItemsNextButton(
+                self.session_id,
+                disabled=self.page >= self.total_pages,
             )
-
-        prev_button.callback = _prev_callback
-        next_button.callback = _next_callback
-        add_button.callback = _add_callback
-        options_button.callback = _options_callback
-
-        self.add_item(prev_button)
-        self.add_item(next_button)
-        self.add_item(add_button)
-        self.add_item(options_button)
+        )
+        self.add_item(
+            TodoListItemsAddButton(
+                self.session_id,
+                disabled=(self.view_scope != "list") or (self.todo_list.get("_id") is None),
+            )
+        )
+        self.add_item(
+            TodoListItemsOptionsButton(
+                self.session_id,
+                active=self._has_active_list_options(),
+            )
+        )
 
 
 class TodoDeleteConfirmModal(discord.ui.Modal):

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from views.reminder_dynamic_items import register_reminder_dynamic_items
 from views.stock_list_dynamic_items import register_stock_list_dynamic_items
 from views.scheduled_job_dynamic_items import register_scheduled_job_dynamic_items
 from views.stock_alert_dynamic_items import register_stock_alert_dynamic_items
+from views.stock_action_dynamic_items import register_stock_action_dynamic_items
 from views.todo_list_directory_dynamic_items import (
     register_todo_list_directory_dynamic_items,
 )
@@ -179,6 +180,7 @@ async def main():
     await register_stock_list_dynamic_items(bot)
     await register_scheduled_job_dynamic_items(bot)
     await register_stock_alert_dynamic_items(bot)
+    await register_stock_action_dynamic_items(bot)
     await register_todo_list_directory_dynamic_items(bot)
     await register_todo_list_description_dynamic_items(bot)
     await register_todo_list_items_dynamic_items(bot)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from services.error_reporting import handle_app_command_error
 from views.habit_dynamic_items import register_habit_dynamic_items
 from views.pomodoro_dynamic_items import register_pomodoro_dynamic_items
 from views.reminder_dynamic_items import register_reminder_dynamic_items
+from views.stock_list_dynamic_items import register_stock_list_dynamic_items
 from views.scheduled_job_dynamic_items import register_scheduled_job_dynamic_items
 from views.stock_alert_dynamic_items import register_stock_alert_dynamic_items
 
@@ -167,6 +168,7 @@ async def main():
     await register_habit_dynamic_items(bot)
     await register_pomodoro_dynamic_items(bot)
     await register_reminder_dynamic_items(bot)
+    await register_stock_list_dynamic_items(bot)
     await register_scheduled_job_dynamic_items(bot)
     await register_stock_alert_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from services.error_reporting import handle_app_command_error
 from views.habit_dynamic_items import register_habit_dynamic_items
 from views.pomodoro_dynamic_items import register_pomodoro_dynamic_items
 from views.reminder_dynamic_items import register_reminder_dynamic_items
+from views.stock_alert_dynamic_items import register_stock_alert_dynamic_items
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
 alias_disabled = env.get("ALIAS_DISABLED") == "true"
@@ -165,6 +166,7 @@ async def main():
     await register_habit_dynamic_items(bot)
     await register_pomodoro_dynamic_items(bot)
     await register_reminder_dynamic_items(bot)
+    await register_stock_alert_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 
 

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 from config.env import env
 from config.logger import setup_logging
 from services.error_reporting import handle_app_command_error
+from views.habit_dynamic_items import register_habit_dynamic_items
 from views.pomodoro_dynamic_items import register_pomodoro_dynamic_items
 from views.reminder_dynamic_items import register_reminder_dynamic_items
 
@@ -161,6 +162,7 @@ async def load():
 
 async def main():
     await load()
+    await register_habit_dynamic_items(bot)
     await register_pomodoro_dynamic_items(bot)
     await register_reminder_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 from config.env import env
 from config.logger import setup_logging
 from services.error_reporting import handle_app_command_error
+from views.pomodoro_dynamic_items import register_pomodoro_dynamic_items
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
 alias_disabled = env.get("ALIAS_DISABLED") == "true"
@@ -159,6 +160,7 @@ async def load():
 
 async def main():
     await load()
+    await register_pomodoro_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,9 @@ from views.stock_alert_dynamic_items import register_stock_alert_dynamic_items
 from views.todo_list_directory_dynamic_items import (
     register_todo_list_directory_dynamic_items,
 )
+from views.todo_list_description_dynamic_items import (
+    register_todo_list_description_dynamic_items,
+)
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
 alias_disabled = env.get("ALIAS_DISABLED") == "true"
@@ -175,6 +178,7 @@ async def main():
     await register_scheduled_job_dynamic_items(bot)
     await register_stock_alert_dynamic_items(bot)
     await register_todo_list_directory_dynamic_items(bot)
+    await register_todo_list_description_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from views.todo_list_description_dynamic_items import (
     register_todo_list_description_dynamic_items,
 )
 from views.todo_list_items_dynamic_items import register_todo_list_items_dynamic_items
+from views.toggl_dynamic_items import register_toggl_dynamic_items
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
 alias_disabled = env.get("ALIAS_DISABLED") == "true"
@@ -181,6 +182,7 @@ async def main():
     await register_todo_list_directory_dynamic_items(bot)
     await register_todo_list_description_dynamic_items(bot)
     await register_todo_list_items_dynamic_items(bot)
+    await register_toggl_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from views.stock_list_dynamic_items import register_stock_list_dynamic_items
 from views.scheduled_job_dynamic_items import register_scheduled_job_dynamic_items
 from views.stock_alert_dynamic_items import register_stock_alert_dynamic_items
 from views.stock_action_dynamic_items import register_stock_action_dynamic_items
+from views.crypto_action_dynamic_items import register_crypto_action_dynamic_items
 from views.todo_list_directory_dynamic_items import (
     register_todo_list_directory_dynamic_items,
 )
@@ -181,6 +182,7 @@ async def main():
     await register_scheduled_job_dynamic_items(bot)
     await register_stock_alert_dynamic_items(bot)
     await register_stock_action_dynamic_items(bot)
+    await register_crypto_action_dynamic_items(bot)
     await register_todo_list_directory_dynamic_items(bot)
     await register_todo_list_description_dynamic_items(bot)
     await register_todo_list_items_dynamic_items(bot)

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from config.env import env
 from config.logger import setup_logging
 from services.error_reporting import handle_app_command_error
 from views.pomodoro_dynamic_items import register_pomodoro_dynamic_items
+from views.reminder_dynamic_items import register_reminder_dynamic_items
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
 alias_disabled = env.get("ALIAS_DISABLED") == "true"
@@ -161,6 +162,7 @@ async def load():
 async def main():
     await load()
     await register_pomodoro_dynamic_items(bot)
+    await register_reminder_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 
 

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from views.todo_list_directory_dynamic_items import (
 from views.todo_list_description_dynamic_items import (
     register_todo_list_description_dynamic_items,
 )
+from views.todo_list_items_dynamic_items import register_todo_list_items_dynamic_items
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
 alias_disabled = env.get("ALIAS_DISABLED") == "true"
@@ -179,6 +180,7 @@ async def main():
     await register_stock_alert_dynamic_items(bot)
     await register_todo_list_directory_dynamic_items(bot)
     await register_todo_list_description_dynamic_items(bot)
+    await register_todo_list_items_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 
 

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from services.error_reporting import handle_app_command_error
 from views.habit_dynamic_items import register_habit_dynamic_items
 from views.pomodoro_dynamic_items import register_pomodoro_dynamic_items
 from views.reminder_dynamic_items import register_reminder_dynamic_items
+from views.scheduled_job_dynamic_items import register_scheduled_job_dynamic_items
 from views.stock_alert_dynamic_items import register_stock_alert_dynamic_items
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
@@ -166,6 +167,7 @@ async def main():
     await register_habit_dynamic_items(bot)
     await register_pomodoro_dynamic_items(bot)
     await register_reminder_dynamic_items(bot)
+    await register_scheduled_job_dynamic_items(bot)
     await register_stock_alert_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,9 @@ from views.reminder_dynamic_items import register_reminder_dynamic_items
 from views.stock_list_dynamic_items import register_stock_list_dynamic_items
 from views.scheduled_job_dynamic_items import register_scheduled_job_dynamic_items
 from views.stock_alert_dynamic_items import register_stock_alert_dynamic_items
+from views.todo_list_directory_dynamic_items import (
+    register_todo_list_directory_dynamic_items,
+)
 
 tick_disabled = env.get("TICK_DISABLED") == "true"
 alias_disabled = env.get("ALIAS_DISABLED") == "true"
@@ -171,6 +174,7 @@ async def main():
     await register_stock_list_dynamic_items(bot)
     await register_scheduled_job_dynamic_items(bot)
     await register_stock_alert_dynamic_items(bot)
+    await register_todo_list_directory_dynamic_items(bot)
     await bot.start(env["DISCORD_TOKEN"])
 
 

--- a/services/reminder_list_sessions.py
+++ b/services/reminder_list_sessions.py
@@ -1,0 +1,107 @@
+import datetime
+import uuid
+from typing import Any, Dict, Optional
+
+from config.db import mongo_db
+
+_COLLECTION = mongo_db["reminder_list_sessions"]
+_SESSION_TTL = datetime.timedelta(days=7)
+
+
+def _ensure_indexes() -> None:
+    _COLLECTION.create_index(
+        [("session_id", 1)],
+        unique=True,
+        name="reminder_list_sessions_session_id",
+    )
+    _COLLECTION.create_index(
+        [("expires_at", 1)],
+        expireAfterSeconds=0,
+        name="reminder_list_sessions_expires_at_ttl",
+    )
+
+
+_ensure_indexes()
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.utcnow()
+
+
+def _expiry() -> datetime.datetime:
+    return _now() + _SESSION_TTL
+
+
+def _state_document(state: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "scope_label": str(state.get("scope_label") or "").strip(),
+        "target_value": str(state.get("target_value") or "").strip(),
+        "status_filter": str(state.get("status_filter") or "all").strip(),
+        "guild_id": state.get("guild_id"),
+        "channel_id": state.get("channel_id"),
+        "destination_type": state.get("destination_type"),
+        "user_id": state.get("user_id"),
+        "sort": str(state.get("sort") or "ascending").strip(),
+        "response_ephemeral": bool(state.get("response_ephemeral", False)),
+        "page": max(1, int(state.get("page") or 1)),
+        "search_query": str(state.get("search_query") or ""),
+        "ping_filter_user_ids": [
+            int(user_id)
+            for user_id in list(state.get("ping_filter_user_ids") or [])
+        ][:25],
+        "ping_filter_label": str(state.get("ping_filter_label") or "All").strip()
+        or "All",
+    }
+
+
+def create_session(state: Dict[str, Any]) -> str:
+    document = _state_document(state)
+    for _ in range(5):
+        session_id = uuid.uuid4().hex[:16]
+        payload = dict(document)
+        payload.update(
+            {
+                "session_id": session_id,
+                "created_at": _now(),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        )
+        try:
+            _COLLECTION.insert_one(payload)
+        except Exception:
+            continue
+        return session_id
+    raise RuntimeError("Could not create a reminder list session.")
+
+
+def save_session(session_id: str, state: Dict[str, Any]) -> None:
+    _COLLECTION.update_one(
+        {"session_id": str(session_id)},
+        {
+            "$set": {
+                **_state_document(state),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        },
+        upsert=False,
+    )
+
+
+def get_session(session_id: str) -> Optional[Dict[str, Any]]:
+    if not session_id:
+        return None
+    document = _COLLECTION.find_one({"session_id": str(session_id)})
+    if not document:
+        return None
+    return {
+        "session_id": str(document.get("session_id") or "").strip(),
+        **_state_document(document),
+    }
+
+
+def delete_session(session_id: str) -> None:
+    if not session_id:
+        return
+    _COLLECTION.delete_one({"session_id": str(session_id)})

--- a/services/stock_list_sessions.py
+++ b/services/stock_list_sessions.py
@@ -1,0 +1,97 @@
+import datetime
+import uuid
+from typing import Any, Dict, Optional
+
+from config.db import mongo_db
+
+_COLLECTION = mongo_db["stock_list_sessions"]
+_SESSION_TTL = datetime.timedelta(days=7)
+
+
+def _ensure_indexes() -> None:
+    _COLLECTION.create_index(
+        [("session_id", 1)],
+        unique=True,
+        name="stock_list_sessions_session_id",
+    )
+    _COLLECTION.create_index(
+        [("expires_at", 1)],
+        expireAfterSeconds=0,
+        name="stock_list_sessions_expires_at_ttl",
+    )
+
+
+_ensure_indexes()
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.utcnow()
+
+
+def _expiry() -> datetime.datetime:
+    return _now() + _SESSION_TTL
+
+
+def _state_document(state: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "user_id": int(state.get("user_id") or 0),
+        "guild_id": state.get("guild_id"),
+        "channel_id": state.get("channel_id"),
+        "kind": str(state.get("kind") or "all").strip(),
+        "page": max(1, int(state.get("page") or 1)),
+        "selected_entry_type": str(state.get("selected_entry_type") or "").strip(),
+        "selected_entry_id": str(state.get("selected_entry_id") or "").strip(),
+    }
+
+
+def create_session(state: Dict[str, Any]) -> str:
+    document = _state_document(state)
+    for _ in range(5):
+        session_id = uuid.uuid4().hex[:16]
+        payload = dict(document)
+        payload.update(
+            {
+                "session_id": session_id,
+                "created_at": _now(),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        )
+        try:
+            _COLLECTION.insert_one(payload)
+        except Exception:
+            continue
+        return session_id
+    raise RuntimeError("Could not create a stock list session.")
+
+
+def save_session(session_id: str, state: Dict[str, Any]) -> None:
+    _COLLECTION.update_one(
+        {"session_id": str(session_id)},
+        {
+            "$set": {
+                **_state_document(state),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        },
+        upsert=False,
+    )
+
+
+def get_session(session_id: str) -> Optional[Dict[str, Any]]:
+    if not session_id:
+        return None
+    document = _COLLECTION.find_one({"session_id": str(session_id)})
+    if not document:
+        return None
+    return {
+        "session_id": str(document.get("session_id") or "").strip(),
+        **_state_document(document),
+    }
+
+
+def delete_session(session_id: str) -> None:
+    if not session_id:
+        return
+    _COLLECTION.delete_one({"session_id": str(session_id)})

--- a/services/todo_list_directory_sessions.py
+++ b/services/todo_list_directory_sessions.py
@@ -1,0 +1,92 @@
+import datetime
+import uuid
+from typing import Any, Dict, Optional
+
+from config.db import mongo_db
+
+_COLLECTION = mongo_db["todo_list_directory_sessions"]
+_SESSION_TTL = datetime.timedelta(days=7)
+
+
+def _ensure_indexes() -> None:
+    _COLLECTION.create_index(
+        [("session_id", 1)],
+        unique=True,
+        name="todo_list_directory_sessions_session_id",
+    )
+    _COLLECTION.create_index(
+        [("expires_at", 1)],
+        expireAfterSeconds=0,
+        name="todo_list_directory_sessions_expires_at_ttl",
+    )
+
+
+_ensure_indexes()
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.utcnow()
+
+
+def _expiry() -> datetime.datetime:
+    return _now() + _SESSION_TTL
+
+
+def _state_document(state: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "current_scope": str(state.get("current_scope") or "server").strip(),
+        "guild_id": state.get("guild_id"),
+        "channel_id": state.get("channel_id"),
+        "channel_name": str(state.get("channel_name") or "").strip() or None,
+        "user_id": state.get("user_id"),
+        "page": max(1, int(state.get("page") or 1)),
+        "page_size": max(1, int(state.get("page_size") or 5)),
+        "sort_direction": str(state.get("sort_direction") or "ascending").strip(),
+    }
+
+
+def create_session(state: Dict[str, Any]) -> str:
+    document = _state_document(state)
+    for _ in range(5):
+        session_id = uuid.uuid4().hex[:16]
+        payload = dict(document)
+        payload.update(
+            {
+                "session_id": session_id,
+                "created_at": _now(),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        )
+        try:
+            _COLLECTION.insert_one(payload)
+        except Exception:
+            continue
+        return session_id
+    raise RuntimeError("Could not create a todo list directory session.")
+
+
+def save_session(session_id: str, state: Dict[str, Any]) -> None:
+    _COLLECTION.update_one(
+        {"session_id": str(session_id)},
+        {
+            "$set": {
+                **_state_document(state),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        },
+        upsert=False,
+    )
+
+
+def get_session(session_id: str) -> Optional[Dict[str, Any]]:
+    if not session_id:
+        return None
+    document = _COLLECTION.find_one({"session_id": str(session_id)})
+    if not document:
+        return None
+    return {
+        "session_id": str(document.get("session_id") or "").strip(),
+        **_state_document(document),
+    }

--- a/services/todo_list_item_sessions.py
+++ b/services/todo_list_item_sessions.py
@@ -1,0 +1,103 @@
+import datetime
+import uuid
+from typing import Any, Dict, Optional
+
+from config.db import mongo_db
+
+_COLLECTION = mongo_db["todo_list_item_sessions"]
+_SESSION_TTL = datetime.timedelta(days=7)
+
+
+def _ensure_indexes() -> None:
+    _COLLECTION.create_index(
+        [("session_id", 1)],
+        unique=True,
+        name="todo_list_item_sessions_session_id",
+    )
+    _COLLECTION.create_index(
+        [("expires_at", 1)],
+        expireAfterSeconds=0,
+        name="todo_list_item_sessions_expires_at_ttl",
+    )
+
+
+_ensure_indexes()
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.utcnow()
+
+
+def _expiry() -> datetime.datetime:
+    return _now() + _SESSION_TTL
+
+
+def _state_document(state: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "todo_list_id": str(state.get("todo_list_id") or "").strip(),
+        "todo_list_name": str(state.get("todo_list_name") or "").strip(),
+        "todo_scope": str(state.get("todo_scope") or "channel").strip(),
+        "todo_channel_id": state.get("todo_channel_id"),
+        "todo_user_id": state.get("todo_user_id"),
+        "sort": str(state.get("sort") or "ascending").strip(),
+        "status_filter": str(state.get("status_filter") or "all").strip(),
+        "assignee_filter_ids": [
+            int(value) for value in list(state.get("assignee_filter_ids") or [])
+        ][:25],
+        "assignee_filter_unassigned": bool(
+            state.get("assignee_filter_unassigned", False)
+        ),
+        "user_id": state.get("user_id"),
+        "view_scope": str(state.get("view_scope") or "list").strip(),
+        "guild_id": state.get("guild_id"),
+        "page": max(1, int(state.get("page") or 1)),
+        "page_size": max(1, int(state.get("page_size") or 5)),
+        "search_query": str(state.get("search_query") or "").strip(),
+    }
+
+
+def create_session(state: Dict[str, Any]) -> str:
+    document = _state_document(state)
+    for _ in range(5):
+        session_id = uuid.uuid4().hex[:16]
+        payload = dict(document)
+        payload.update(
+            {
+                "session_id": session_id,
+                "created_at": _now(),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        )
+        try:
+            _COLLECTION.insert_one(payload)
+        except Exception:
+            continue
+        return session_id
+    raise RuntimeError("Could not create a todo list item session.")
+
+
+def save_session(session_id: str, state: Dict[str, Any]) -> None:
+    _COLLECTION.update_one(
+        {"session_id": str(session_id)},
+        {
+            "$set": {
+                **_state_document(state),
+                "updated_at": _now(),
+                "expires_at": _expiry(),
+            }
+        },
+        upsert=False,
+    )
+
+
+def get_session(session_id: str) -> Optional[Dict[str, Any]]:
+    if not session_id:
+        return None
+    document = _COLLECTION.find_one({"session_id": str(session_id)})
+    if not document:
+        return None
+    return {
+        "session_id": str(document.get("session_id") or "").strip(),
+        **_state_document(document),
+    }

--- a/views/CryptoActionView.py
+++ b/views/CryptoActionView.py
@@ -193,6 +193,7 @@ class CryptoAlertModal(discord.ui.Modal, title="Create Crypto Alert"):
 
             timezone = None
             if expires_text:
+
                 async def _continue_with_timezone(
                     followup_interaction: discord.Interaction,
                     resolved_timezone: str,
@@ -346,6 +347,7 @@ class CryptoDailyJobModal(discord.ui.Modal, title="Schedule Daily Crypto Check")
 
             timezone = None
             if not is_valid_cron_expression(raw_schedule):
+
                 async def _continue_with_timezone(
                     followup_interaction: discord.Interaction,
                     resolved_timezone: str,
@@ -388,17 +390,43 @@ class CryptoDailyJobModal(discord.ui.Modal, title="Schedule Daily Crypto Check")
 
 
 class CryptoActionView(discord.ui.View):
-    def __init__(self, coin_id: str, currency: str, *, timeout: float = 3600) -> None:
+    def __init__(
+        self,
+        coin_id: str,
+        currency: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
         super().__init__(timeout=timeout)
         self.coin_id = coin_id.strip().lower()
         self.currency = currency.strip().lower() or "usd"
+        self._build()
 
-    @discord.ui.button(label="Set Alert", style=discord.ButtonStyle.success)
-    async def set_alert(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
+    def _build(self) -> None:
+        self.clear_items()
+
+        from views.crypto_action_dynamic_items import (
+            CryptoScheduleDailyCheckButton,
+            CryptoSetAlertButton,
+        )
+
+        has_coin = bool(self.coin_id)
+        self.add_item(
+            CryptoSetAlertButton(
+                coin_id=self.coin_id,
+                currency=self.currency,
+                disabled=not has_coin,
+            )
+        )
+        self.add_item(
+            CryptoScheduleDailyCheckButton(
+                coin_id=self.coin_id,
+                currency=self.currency,
+                disabled=not has_coin,
+            )
+        )
+
+    async def open_set_alert_modal(self, interaction: discord.Interaction) -> None:
         if not self.coin_id:
             await handle_interaction_error(
                 interaction,
@@ -412,13 +440,9 @@ class CryptoActionView(discord.ui.View):
             )
         )
 
-    @discord.ui.button(
-        label="Schedule Daily Check", style=discord.ButtonStyle.secondary
-    )
-    async def schedule_daily_check(
+    async def open_schedule_daily_check_modal(
         self,
         interaction: discord.Interaction,
-        _: discord.ui.Button,
     ) -> None:
         if not self.coin_id:
             await handle_interaction_error(

--- a/views/HabitActionView.py
+++ b/views/HabitActionView.py
@@ -3,6 +3,7 @@ import asyncio
 import discord
 
 from classes.HabitFunctions import HabitFunctions
+from embeds.HabitEmbeds import HabitEmbeds
 
 
 class HabitActionView(discord.ui.View):
@@ -12,61 +13,73 @@ class HabitActionView(discord.ui.View):
         habit_name: str,
         user_id: int,
         *,
-        timeout: float = 3600,
+        timeout: float | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.habit_id = habit_id
         self.habit_name = habit_name
         self.user_id = user_id
+        self._rebuild_items()
 
-    async def _record(self, interaction: discord.Interaction, mode: str) -> None:
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message(
-                ephemeral=True,
-                content="Only the habit owner can update this habit.",
+    def _rebuild_items(self, *, disabled: bool = False) -> None:
+        from views.habit_dynamic_items import (
+            HabitCompleteButton,
+            HabitIncompleteButton,
+            HabitSkipButton,
+        )
+
+        self.clear_items()
+        self.add_item(
+            HabitCompleteButton(
+                self.habit_id,
+                self.user_id,
+                disabled=disabled,
             )
-            return
+        )
+        self.add_item(
+            HabitSkipButton(
+                self.habit_id,
+                self.user_id,
+                disabled=disabled,
+            )
+        )
+        self.add_item(
+            HabitIncompleteButton(
+                self.habit_id,
+                self.user_id,
+                disabled=disabled,
+            )
+        )
 
-        await interaction.response.defer(ephemeral=True)
-        updated = await asyncio.to_thread(
-            HabitFunctions.add_completion,
+    async def refresh_message(self, interaction: discord.Interaction) -> bool:
+        habit = await asyncio.to_thread(
+            HabitFunctions.fetch_habit,
             self.habit_id,
             interaction.guild_id,
-            mode,
         )
 
-        if not updated:
-            await interaction.followup.send(
-                ephemeral=True,
-                content=f"Couldn't update '{self.habit_name}'.",
+        if habit is None:
+            self._rebuild_items(disabled=True)
+            embed = discord.Embed(
+                title=self.habit_name or "Habit",
+                description="This habit is no longer available.",
+                color=discord.Colour.red(),
             )
-            return
+        else:
+            self.habit_name = str(habit.get("name") or self.habit_name or "Habit")
+            self._rebuild_items()
+            payload = HabitEmbeds.habit_item_embed(
+                habit,
+                HabitFunctions.today_status(habit),
+                HabitFunctions.recent_progress(habit, days=5),
+            )
+            embed = payload["embed"]
 
-        await interaction.followup.send(
-            ephemeral=True,
-            content=f"Marked '{self.habit_name}' as {mode}.",
-        )
+        if interaction.message is None:
+            return False
 
-    @discord.ui.button(label="complete", style=discord.ButtonStyle.success)
-    async def complete_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._record(interaction, "complete")
-
-    @discord.ui.button(label="skip", style=discord.ButtonStyle.secondary)
-    async def skip_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._record(interaction, "skip")
-
-    @discord.ui.button(label="incomplete", style=discord.ButtonStyle.danger)
-    async def incomplete_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._record(interaction, "incomplete")
+        try:
+            await interaction.message.edit(embed=embed, view=self)
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            return False
+        return True

--- a/views/PomodoroRestartView.py
+++ b/views/PomodoroRestartView.py
@@ -1,101 +1,20 @@
-import asyncio
 from typing import Optional
 
 import discord
 
-from classes.PomodoroFunctions import PomodoroFunctions
-from classes.PomodoroVoiceManager import PomodoroVoiceManager
-from embeds.PomodoroEmbeds import PomodoroEmbeds
-from views.PomodoroStartView import PomodoroStartView
-from services.error_reporting import ValidationError, UserVisibleError, handle_interaction_error
+from views.pomodoro_dynamic_items import (
+    PomodoroRestartBreakButton,
+    PomodoroRestartFocusButton,
+)
 
 
 class PomodoroRestartView(discord.ui.View):
-    def __init__(self, *, timeout: float = 21600) -> None:
+    def __init__(
+        self,
+        *,
+        disabled: bool = False,
+        timeout: Optional[float] = None,
+    ) -> None:
         super().__init__(timeout=timeout)
-
-    async def _start(
-        self, interaction: discord.Interaction, mode: str
-    ) -> None:
-        await interaction.response.defer(ephemeral=False)
-
-        try:
-            end_time, resolved_duration = await asyncio.to_thread(
-                PomodoroFunctions.create_timer,
-                interaction.guild_id,
-                interaction.channel_id,
-                mode,
-                None,
-                interaction.user.id,
-            )
-        except ValueError as exc:
-            await handle_interaction_error(
-                interaction,
-                ValidationError(
-                    str(exc),
-                    ephemeral=False,
-                    cause=exc,
-                ),
-            )
-            return
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                UserVisibleError(
-                    "Something went wrong while starting that pomodoro.",
-                    ephemeral=False,
-                    cause=exc,
-                ),
-            )
-            return
-
-        voice_error: Optional[str] = None
-        target_channel: Optional[discord.VoiceChannel] = None
-
-        if interaction.guild is None:
-            voice_error = None
-        else:
-            member = interaction.user
-            if isinstance(member, discord.Member) and member.voice:
-                target_channel = member.voice.channel
-
-            if target_channel is None:
-                voice_error = "Join a voice channel so I can play audio."
-            else:
-                voice_error = await PomodoroVoiceManager.start_session(
-                    interaction.guild,
-                    target_channel,
-                    end_time,
-                    mode,
-                )
-
-        payload = PomodoroEmbeds.insert_timer_embed(
-            mode,
-            resolved_duration,
-            end_time,
-        )
-        join_url = target_channel.jump_url if target_channel else None
-        payload["view"] = PomodoroStartView(
-            interaction.user.id,
-            join_url=join_url,
-            mode=mode,
-            end_time=end_time,
-            voice_channel_select_enabled=interaction.guild is not None,
-        )
-
-        await interaction.followup.send(ephemeral=False, **payload)
-
-        if voice_error:
-            await interaction.followup.send(ephemeral=False, content=voice_error)
-
-    @discord.ui.button(label="Start Focus", style=discord.ButtonStyle.success)
-    async def start_focus(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        await self._start(interaction, "focus")
-
-    @discord.ui.button(label="Start Relax", style=discord.ButtonStyle.secondary)
-    async def start_break(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        await self._start(interaction, "break")
+        self.add_item(PomodoroRestartFocusButton(disabled=disabled))
+        self.add_item(PomodoroRestartBreakButton(disabled=disabled))

--- a/views/PomodoroStartView.py
+++ b/views/PomodoroStartView.py
@@ -3,6 +3,13 @@ from typing import List, Optional
 
 import discord
 
+from views.pomodoro_dynamic_items import (
+    PomodoroStartExtendButton,
+    PomodoroStartPlayPauseButton,
+    PomodoroStartSelectVoiceButton,
+    PomodoroStartStopButton,
+)
+
 _POMODORO_MODAL_SELECTS_SUPPORTED = True
 
 
@@ -259,23 +266,19 @@ class PomodoroStartView(discord.ui.View):
         is_paused: bool = False,
         voice_channel_select_enabled: bool = True,
         *,
-        timeout: float = 21600,
+        timeout: Optional[float] = None,
     ) -> None:
         super().__init__(timeout=timeout)
-        self._user_id = user_id
-        self._mode = mode
-        self._end_time = end_time
-        self._is_paused = is_paused
-        self._voice_channel_select_enabled = voice_channel_select_enabled
-
-        if not self._voice_channel_select_enabled:
-            self.select_voice_channel_button.disabled = True
-            self.select_voice_channel_button.label = (
-                "Select Voice Channel (Server only)"
+        self.add_item(
+            PomodoroStartSelectVoiceButton(
+                user_id,
+                disabled=not voice_channel_select_enabled,
+                server_only=not voice_channel_select_enabled,
             )
-            self.select_voice_channel_button.style = discord.ButtonStyle.secondary
-
-        self._sync_play_pause_button()
+        )
+        self.add_item(PomodoroStartPlayPauseButton(user_id, paused=is_paused))
+        self.add_item(PomodoroStartExtendButton(user_id, disabled=is_paused))
+        self.add_item(PomodoroStartStopButton(user_id))
 
         if join_url:
             self.add_item(discord.ui.Button(label="Join Voice", url=join_url))
@@ -311,21 +314,8 @@ class PomodoroStartView(discord.ui.View):
                 )
         return updated
 
-    def _sync_play_pause_button(self) -> None:
-        if self._is_paused:
-            self.play_pause_button.label = "Resume"
-            self.play_pause_button.emoji = "▶️"
-            self.play_pause_button.style = discord.ButtonStyle.success
-            self.extend_timer_button.disabled = True
-            return
-
-        self.play_pause_button.label = "Pause"
-        self.play_pause_button.emoji = "⏸️"
-        self.play_pause_button.style = discord.ButtonStyle.secondary
-        self.extend_timer_button.disabled = False
-
+    @staticmethod
     def _with_paused_timer_fields(
-        self,
         embed: Optional[discord.Embed],
         mode: str,
         remaining_minutes: int,
@@ -356,14 +346,18 @@ class PomodoroStartView(discord.ui.View):
                 )
         return updated
 
+    @staticmethod
     def _with_resumed_timer_fields(
-        self,
         embed: Optional[discord.Embed],
         mode: str,
         end_time: datetime.datetime,
         duration_minutes: int,
     ) -> Optional[discord.Embed]:
-        updated = self._with_updated_timer_fields(embed, end_time, duration_minutes)
+        updated = PomodoroStartView._with_updated_timer_fields(
+            embed,
+            end_time,
+            duration_minutes,
+        )
         if updated is None:
             return None
 
@@ -371,249 +365,3 @@ class PomodoroStartView(discord.ui.View):
         updated.description = f"{mode.capitalize()} timer resumed."
         updated.color = discord.Colour.green()
         return updated
-
-    @discord.ui.button(label="Select Voice Channel", style=discord.ButtonStyle.primary)
-    async def select_voice_channel_button(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        global _POMODORO_MODAL_SELECTS_SUPPORTED
-
-        if interaction.user.id != self._user_id:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content="Only the user who started this pomodoro can do this.",
-            )
-            return
-
-        if interaction.guild is None:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content="Voice channel selection isn't available in DMs.",
-            )
-            return
-
-        voice_channel_options = (
-            PomodoroVoiceChannelSelectView._build_voice_channel_options(interaction)
-        )
-        if not voice_channel_options:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content="No available voice channels found.",
-            )
-            return
-
-        if _POMODORO_MODAL_SELECTS_SUPPORTED:
-            try:
-                await interaction.response.send_modal(
-                    PomodoroVoiceChannelSelectModal(
-                        user_id=self._user_id,
-                        mode=self._mode,
-                        end_time=self._end_time,
-                        voice_channel_options=voice_channel_options,
-                    )
-                )
-                return
-            except discord.HTTPException as exc:
-                if exc.code == 50035 and "must be one of (4,)" in str(exc):
-                    _POMODORO_MODAL_SELECTS_SUPPORTED = False
-                else:
-                    raise
-
-        picker_view = PomodoroVoiceChannelSelectView(
-            interaction=interaction,
-            user_id=self._user_id,
-            mode=self._mode,
-            end_time=self._end_time,
-        )
-        await interaction.response.send_message(
-            ephemeral=False,
-            content="Choose a voice channel:",
-            view=picker_view,
-        )
-
-    @discord.ui.button(
-        label="Pause",
-        style=discord.ButtonStyle.secondary,
-        emoji="⏸️",
-    )
-    async def play_pause_button(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        if interaction.user.id != self._user_id:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content="Only the user who started this pomodoro can do this.",
-            )
-            return
-
-        from classes.PomodoroFunctions import PomodoroFunctions
-
-        if self._is_paused:
-            result = await PomodoroFunctions.resume_user_pomodoro(interaction)
-            if (
-                not result.ok
-                or result.end_time is None
-                or result.duration_minutes is None
-            ):
-                await interaction.response.send_message(
-                    ephemeral=False,
-                    content=result.message,
-                )
-                return
-
-            self._is_paused = False
-            self._end_time = result.end_time
-            if result.mode:
-                self._mode = result.mode
-            self._sync_play_pause_button()
-
-            updated_embed = self._with_resumed_timer_fields(
-                (
-                    interaction.message.embeds[0]
-                    if interaction.message and interaction.message.embeds
-                    else None
-                ),
-                self._mode,
-                result.end_time,
-                result.duration_minutes,
-            )
-            if updated_embed is None:
-                await interaction.response.send_message(
-                    ephemeral=False,
-                    content=(
-                        "Pomodoro resumed, but I couldn't refresh the timer card. "
-                        f"New end: {self._relative_timestamp(result.end_time)}"
-                    ),
-                )
-                return
-
-            await interaction.response.edit_message(embed=updated_embed, view=self)
-            return
-
-        result = await PomodoroFunctions.pause_user_pomodoro(interaction)
-        if not result.ok:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content=result.message,
-            )
-            return
-
-        remaining_minutes = result.remaining_minutes or 1
-        if result.mode:
-            self._mode = result.mode
-        self._end_time = None
-        self._is_paused = True
-        self._sync_play_pause_button()
-
-        updated_embed = self._with_paused_timer_fields(
-            (
-                interaction.message.embeds[0]
-                if interaction.message and interaction.message.embeds
-                else None
-            ),
-            self._mode,
-            remaining_minutes,
-        )
-        if updated_embed is None:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content=f"Paused with {remaining_minutes} minute(s) remaining.",
-            )
-            return
-
-        await interaction.response.edit_message(embed=updated_embed, view=self)
-
-    @discord.ui.button(label="Extend +5 min", style=discord.ButtonStyle.secondary)
-    async def extend_timer_button(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        if interaction.user.id != self._user_id:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content="Only the user who started this pomodoro can do this.",
-            )
-            return
-
-        if self._is_paused:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content="Resume the pomodoro before extending it.",
-            )
-            return
-
-        from classes.PomodoroFunctions import PomodoroFunctions
-
-        result = await PomodoroFunctions.extend_user_pomodoro(
-            interaction,
-            minutes=5,
-            expected_end_time=self._end_time,
-        )
-        if not result.ok or result.end_time is None or result.duration_minutes is None:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content=result.message,
-            )
-            return
-
-        self._end_time = result.end_time
-        updated_embed = self._with_updated_timer_fields(
-            (
-                interaction.message.embeds[0]
-                if interaction.message and interaction.message.embeds
-                else None
-            ),
-            result.end_time,
-            result.duration_minutes,
-        )
-        if updated_embed is None:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content=(
-                    "Extended by 5 minutes, but I couldn't refresh the timer card. "
-                    f"New end: {self._relative_timestamp(result.end_time)}"
-                ),
-            )
-            return
-
-        try:
-            await interaction.response.edit_message(embed=updated_embed, view=self)
-        except discord.HTTPException:
-            fallback_message = (
-                "Extended by 5 minutes, but that timer message no longer exists. "
-                f"New end: {self._relative_timestamp(result.end_time)}"
-            )
-            if interaction.response.is_done():
-                await interaction.followup.send(
-                    ephemeral=False,
-                    content=fallback_message,
-                )
-            else:
-                await interaction.response.send_message(
-                    ephemeral=False,
-                    content=fallback_message,
-                )
-
-    @discord.ui.button(label="Stop Pomodoro", style=discord.ButtonStyle.danger)
-    async def stop_button(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        if interaction.user.id != self._user_id:
-            await interaction.response.send_message(
-                ephemeral=False,
-                content="Only the user who started this pomodoro can stop it.",
-            )
-            return
-
-        await interaction.response.defer(ephemeral=False)
-        from classes.PomodoroFunctions import PomodoroFunctions
-        from embeds.PomodoroEmbeds import PomodoroEmbeds
-        from views.PomodoroStoppedView import PomodoroStoppedView
-
-        result = await PomodoroFunctions.stop_user_pomodoro(interaction)
-        if not result.ok:
-            await interaction.followup.send(ephemeral=False, content=result.message)
-            return
-
-        payload = PomodoroEmbeds.timer_stopped_embed(result.message)
-        payload["view"] = PomodoroStoppedView(interaction.user.id)
-        await interaction.followup.send(ephemeral=False, **payload)

--- a/views/PomodoroStoppedView.py
+++ b/views/PomodoroStoppedView.py
@@ -1,26 +1,64 @@
-import asyncio
 from typing import Optional
 
 import discord
 
-from classes.PomodoroFunctions import PomodoroFunctions
-from classes.PomodoroVoiceManager import PomodoroVoiceManager
-from embeds.PomodoroEmbeds import PomodoroEmbeds
-from services.error_reporting import ValidationError, UserVisibleError, handle_interaction_error
-from views.PomodoroStartView import PomodoroStartView, PomodoroVoiceChannelSelectView
+from views.PomodoroStartView import PomodoroVoiceChannelSelectView
+from views.pomodoro_dynamic_items import (
+    PomodoroStoppedBreakButton,
+    PomodoroStoppedCustomTimerButton,
+    PomodoroStoppedFocusButton,
+    _ensure_stopped_owner,
+    _send_started_pomodoro,
+)
 
 _POMODORO_STOP_MODAL_SELECTS_SUPPORTED = True
+
+
+def build_custom_voice_options(
+    interaction: discord.Interaction,
+) -> list[discord.SelectOption]:
+    options: list[discord.SelectOption] = [
+        discord.SelectOption(
+            label="Auto (your current voice channel)",
+            value="__auto__",
+            default=True,
+        )
+    ]
+    if interaction.guild is not None:
+        for option in PomodoroVoiceChannelSelectView._build_voice_channel_options(
+            interaction
+        ):
+            if not option.value.startswith("voice:"):
+                continue
+            options.append(
+                discord.SelectOption(
+                    label=option.label,
+                    value=option.value,
+                )
+            )
+            if len(options) >= 24:
+                break
+
+    options.append(
+        discord.SelectOption(
+            label="No voice playback",
+            value="__none__",
+        )
+    )
+    return options
 
 
 class PomodoroCustomTimerModal(discord.ui.Modal):
     def __init__(
         self,
         *,
-        parent_view: "PomodoroStoppedView",
+        user_id: int,
+        source_message: Optional[discord.Message],
         voice_options: list[discord.SelectOption],
     ) -> None:
         super().__init__(title="Start Custom Pomodoro")
-        self._parent_view = parent_view
+        self._user_id = user_id
+        self._source_message = source_message
         self.mode_select = discord.ui.Select(
             placeholder="Mode",
             min_values=1,
@@ -56,7 +94,7 @@ class PomodoroCustomTimerModal(discord.ui.Modal):
         self.add_item(self.voice_select_label)
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        if not await self._parent_view._ensure_user(interaction):
+        if not await _ensure_stopped_owner(interaction, self._user_id):
             return
 
         mode = (
@@ -72,27 +110,22 @@ class PomodoroCustomTimerModal(discord.ui.Modal):
         if raw_duration:
             try:
                 duration_value = int(raw_duration)
-            except ValueError as exc:
-                await handle_interaction_error(
-                    interaction,
-                    ValidationError(
-                        "Duration must be a whole number of minutes.",
-                        ephemeral=False,
-                        cause=exc,
-                    ),
+            except ValueError:
+                await interaction.response.send_message(
+                    ephemeral=False,
+                    content="Duration must be a whole number of minutes.",
                 )
                 return
             if duration_value <= 0:
-                await handle_interaction_error(
-                    interaction,
-                    ValidationError(
-                        "Duration must be greater than zero.",
-                        ephemeral=False,
-                    ),
+                await interaction.response.send_message(
+                    ephemeral=False,
+                    content="Duration must be greater than zero.",
                 )
                 return
 
-        voice_selection = self.voice_select.values[0] if self.voice_select.values else "__auto__"
+        voice_selection = (
+            self.voice_select.values[0] if self.voice_select.values else "__auto__"
+        )
         if voice_selection == "__auto__":
             target_channel = None
             use_member_voice = True
@@ -103,12 +136,9 @@ class PomodoroCustomTimerModal(discord.ui.Modal):
             skip_voice = True
         else:
             if interaction.guild is None:
-                await handle_interaction_error(
-                    interaction,
-                    ValidationError(
-                        "Voice channel selection isn't available in DMs.",
-                        ephemeral=False,
-                    ),
+                await interaction.response.send_message(
+                    ephemeral=False,
+                    content="Voice channel selection isn't available in DMs.",
                 )
                 return
             target_channel = PomodoroVoiceChannelSelectView._resolve_selected_voice_channel(
@@ -116,232 +146,37 @@ class PomodoroCustomTimerModal(discord.ui.Modal):
                 voice_selection,
             )
             if target_channel is None:
-                await handle_interaction_error(
-                    interaction,
-                    ValidationError(
-                        "That voice channel was not found.",
-                        ephemeral=False,
-                    ),
+                await interaction.response.send_message(
+                    ephemeral=False,
+                    content="That voice channel was not found.",
                 )
                 return
             use_member_voice = False
             skip_voice = False
 
-        await self._parent_view._start_with_options(
+        await interaction.response.defer(ephemeral=False)
+
+        await _send_started_pomodoro(
             interaction,
             mode=mode,
             duration=duration_value,
             target_channel=target_channel,
             use_member_voice=use_member_voice,
             skip_voice=skip_voice,
+            source_message=self._source_message,
+            source_disabled_view=PomodoroStoppedView(self._user_id, disabled=True),
         )
 
 
 class PomodoroStoppedView(discord.ui.View):
-    def __init__(self, user_id: int, *, timeout: float = 21600) -> None:
-        super().__init__(timeout=timeout)
-        self._user_id = user_id
-
-    async def _ensure_user(self, interaction: discord.Interaction) -> bool:
-        if interaction.user.id == self._user_id:
-            return True
-        await interaction.response.send_message(
-            ephemeral=False,
-            content="Only the user who stopped this pomodoro can do this.",
-        )
-        return False
-
-    def _disable_buttons(self) -> None:
-        for item in self.children:
-            if isinstance(item, discord.ui.Button):
-                item.disabled = True
-
-    @staticmethod
-    def _custom_voice_options(interaction: discord.Interaction) -> list[discord.SelectOption]:
-        options: list[discord.SelectOption] = [
-            discord.SelectOption(
-                label="Auto (your current voice channel)",
-                value="__auto__",
-                default=True,
-            )
-        ]
-        if interaction.guild is not None:
-            for option in PomodoroVoiceChannelSelectView._build_voice_channel_options(
-                interaction
-            ):
-                if not option.value.startswith("voice:"):
-                    continue
-                options.append(
-                    discord.SelectOption(
-                        label=option.label,
-                        value=option.value,
-                    )
-                )
-                if len(options) >= 24:
-                    break
-
-        options.append(
-            discord.SelectOption(
-                label="No voice playback",
-                value="__none__",
-            )
-        )
-        return options
-
-    async def _start_with_options(
+    def __init__(
         self,
-        interaction: discord.Interaction,
+        user_id: int,
         *,
-        mode: str,
-        duration: Optional[int],
-        target_channel: Optional[discord.VoiceChannel],
-        use_member_voice: bool,
-        skip_voice: bool,
+        disabled: bool = False,
+        timeout: Optional[float] = None,
     ) -> None:
-        if not await self._ensure_user(interaction):
-            return
-
-        await interaction.response.defer(ephemeral=False)
-
-        try:
-            end_time, resolved_duration = await asyncio.to_thread(
-                PomodoroFunctions.create_timer,
-                interaction.guild_id,
-                interaction.channel_id,
-                mode,
-                duration,
-                interaction.user.id,
-            )
-        except ValueError as exc:
-            await handle_interaction_error(
-                interaction,
-                ValidationError(
-                    str(exc),
-                    ephemeral=False,
-                    cause=exc,
-                ),
-            )
-            return
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                UserVisibleError(
-                    "Something went wrong while starting that pomodoro.",
-                    ephemeral=False,
-                    cause=exc,
-                ),
-            )
-            return
-
-        voice_error: Optional[str] = None
-        resolved_target_channel = target_channel
-
-        if skip_voice:
-            voice_error = None
-        elif interaction.guild is None:
-            voice_error = None
-        else:
-            member = interaction.user
-            if resolved_target_channel is None and use_member_voice:
-                if isinstance(member, discord.Member) and member.voice:
-                    resolved_target_channel = member.voice.channel
-
-            if resolved_target_channel is None:
-                voice_error = "Join a voice channel so I can play audio."
-            else:
-                voice_error = await PomodoroVoiceManager.start_session(
-                    interaction.guild,
-                    resolved_target_channel,
-                    end_time,
-                    mode,
-                )
-
-        payload = PomodoroEmbeds.insert_timer_embed(
-            mode,
-            resolved_duration,
-            end_time,
-        )
-        join_url = resolved_target_channel.jump_url if resolved_target_channel else None
-        payload["view"] = PomodoroStartView(
-            interaction.user.id,
-            join_url=join_url if voice_error is None else None,
-            mode=mode,
-            end_time=end_time,
-            voice_channel_select_enabled=interaction.guild is not None,
-        )
-        await interaction.followup.send(ephemeral=False, **payload)
-
-        if voice_error:
-            await interaction.followup.send(ephemeral=False, content=voice_error)
-
-        self._disable_buttons()
-        if interaction.message is not None:
-            try:
-                await interaction.message.edit(view=self)
-            except discord.HTTPException:
-                pass
-
-    @discord.ui.button(label="Start Focus", style=discord.ButtonStyle.success)
-    async def start_focus(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._start_with_options(
-            interaction,
-            mode="focus",
-            duration=None,
-            target_channel=None,
-            use_member_voice=True,
-            skip_voice=False,
-        )
-
-    @discord.ui.button(label="Start Break", style=discord.ButtonStyle.primary)
-    async def start_break(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._start_with_options(
-            interaction,
-            mode="break",
-            duration=None,
-            target_channel=None,
-            use_member_voice=True,
-            skip_voice=False,
-        )
-
-    @discord.ui.button(label="Custom Timer", style=discord.ButtonStyle.secondary)
-    async def custom_timer(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if not await self._ensure_user(interaction):
-            return
-
-        global _POMODORO_STOP_MODAL_SELECTS_SUPPORTED
-        voice_options = self._custom_voice_options(interaction)
-
-        if _POMODORO_STOP_MODAL_SELECTS_SUPPORTED:
-            try:
-                await interaction.response.send_modal(
-                    PomodoroCustomTimerModal(
-                        parent_view=self,
-                        voice_options=voice_options,
-                    )
-                )
-                return
-            except discord.HTTPException as exc:
-                if exc.code == 50035 and "must be one of (4,)" in str(exc):
-                    _POMODORO_STOP_MODAL_SELECTS_SUPPORTED = False
-                else:
-                    raise
-
-        await interaction.response.send_message(
-            ephemeral=False,
-            content=(
-                "Custom timer popup with dropdowns is not supported here. "
-                "Use `/pomodoro start` for custom mode, duration, and voice options."
-            ),
-        )
+        super().__init__(timeout=timeout)
+        self.add_item(PomodoroStoppedFocusButton(user_id, disabled=disabled))
+        self.add_item(PomodoroStoppedBreakButton(user_id, disabled=disabled))
+        self.add_item(PomodoroStoppedCustomTimerButton(user_id, disabled=disabled))

--- a/views/ReminderListView.py
+++ b/views/ReminderListView.py
@@ -9,6 +9,7 @@ from classes.DailyJob import DailyJob
 from classes.ReminderFunctions import ReminderFunctions
 from services.channel_visibility import can_view_channel
 from services.error_reporting import ValidationError, UserVisibleError, handle_interaction_error
+from services import reminder_list_sessions
 from views.ReminderOutputView import ReminderOutputView
 from views.ReminderEditModal import ReminderCreateModal
 
@@ -167,6 +168,7 @@ class ReminderListOptionsModal(discord.ui.Modal):
             self.parent_view.page = 1
             await self.parent_view._reload_reminders(interaction)
             self.parent_view._build()
+            await self.parent_view.save_session()
         except (ValidationError, UserVisibleError) as exc:
             await handle_interaction_error(
                 interaction,
@@ -186,11 +188,12 @@ class ReminderListOptionsModal(discord.ui.Modal):
 
         target_message = self.source_message or self.parent_view.message
         if target_message is None:
-            await interaction.followup.send(
+            posted_message = await interaction.followup.send(
                 ephemeral=True,
                 view=self.parent_view,
                 **self.parent_view.payload(),
             )
+            self.parent_view.message = posted_message
             return
 
         try:
@@ -228,8 +231,12 @@ class ReminderListView(discord.ui.View):
         user_id: Optional[int],
         sort: str = "ascending",
         response_ephemeral: bool = False,
+        search_query: str = "",
+        ping_filter_user_ids: Optional[List[int]] = None,
+        ping_filter_label: str = "All",
         page: int = 1,
-        timeout: float = 300,
+        session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self._all_reminders = list(reminders)
@@ -245,17 +252,95 @@ class ReminderListView(discord.ui.View):
         self.channel_id = channel_id
         self.destination_type = destination_type
         self.user_id = user_id
-        self.search_query = ""
-        self.ping_filter_user_ids: List[int] = []
-        self.ping_filter_label = "All"
+        self.search_query = self.normalize_search_query(search_query)
+        self.ping_filter_user_ids = [
+            int(value) for value in list(ping_filter_user_ids or [])
+        ][:25]
+        self.ping_filter_label = str(ping_filter_label or "All").strip() or "All"
         self.sort = sort if sort in {"ascending", "descending"} else "ascending"
+        self.session_id = str(session_id or "").strip() or None
         self.message: Optional[discord.Message] = None
         self.response_ephemeral = bool(response_ephemeral)
         self.page_size = self.PAGE_SIZE
         self.total_pages = 1
         self.page = max(1, page)
         self._apply_filters()
+        if self.session_id is not None:
+            self._build()
+
+    def session_state(self) -> dict:
+        return {
+            "scope_label": self.scope_label,
+            "target_value": self.target_value,
+            "status_filter": self.status_filter,
+            "guild_id": self.guild_id,
+            "channel_id": self.channel_id,
+            "destination_type": self.destination_type,
+            "user_id": self.user_id,
+            "sort": self.sort,
+            "response_ephemeral": self.response_ephemeral,
+            "page": self.page,
+            "search_query": self.search_query,
+            "ping_filter_user_ids": self.ping_filter_user_ids,
+            "ping_filter_label": self.ping_filter_label,
+        }
+
+    async def ensure_session(self) -> str:
+        if self.session_id is None:
+            self.session_id = await asyncio.to_thread(
+                reminder_list_sessions.create_session,
+                self.session_state(),
+            )
+        else:
+            await self.save_session()
         self._build()
+        return self.session_id
+
+    async def save_session(self) -> None:
+        if self.session_id is None:
+            return
+        await asyncio.to_thread(
+            reminder_list_sessions.save_session,
+            self.session_id,
+            self.session_state(),
+        )
+
+    @classmethod
+    async def from_session(
+        cls,
+        interaction: discord.Interaction,
+        session_id: str,
+    ) -> Optional["ReminderListView"]:
+        session = await asyncio.to_thread(
+            reminder_list_sessions.get_session,
+            session_id,
+        )
+        if session is None:
+            return None
+
+        view = cls(
+            reminders=[],
+            scope_label=str(session.get("scope_label") or "").strip(),
+            target_value=str(session.get("target_value") or "").strip(),
+            status_filter=str(session.get("status_filter") or "all").strip(),
+            guild_id=session.get("guild_id"),
+            channel_id=session.get("channel_id"),
+            destination_type=session.get("destination_type"),
+            user_id=session.get("user_id"),
+            sort=str(session.get("sort") or "ascending").strip(),
+            response_ephemeral=bool(session.get("response_ephemeral", False)),
+            search_query=str(session.get("search_query") or ""),
+            ping_filter_user_ids=list(session.get("ping_filter_user_ids") or []),
+            ping_filter_label=str(session.get("ping_filter_label") or "All"),
+            page=max(1, int(session.get("page") or 1)),
+            session_id=str(session.get("session_id") or session_id).strip(),
+        )
+        view.page = max(1, int(session.get("page") or 1))
+        view.message = interaction.message
+        await view._reload_reminders(interaction)
+        view._build()
+        await view.save_session()
+        return view
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if self.user_id is None or interaction.user.id == self.user_id:
@@ -671,6 +756,7 @@ class ReminderListView(discord.ui.View):
         if current_job is None:
             await self._reload_reminders(interaction)
             self._build()
+            await self.save_session()
             await interaction.response.edit_message(view=self, **self.payload())
             return
 
@@ -744,11 +830,14 @@ class ReminderListView(discord.ui.View):
         *,
         source_message: Optional[discord.Message] = None,
         jump_to_last_page: bool = False,
+        result_message: Optional[str] = None,
     ) -> None:
+        del result_message
         await self._reload_reminders(interaction)
         if jump_to_last_page and self.reminders:
             self.page = self.total_pages
         self._build()
+        await self.save_session()
 
         target_message = source_message or interaction.message
         if target_message is None:
@@ -764,29 +853,49 @@ class ReminderListView(discord.ui.View):
             )
 
     def _build(self) -> None:
+        from views.reminder_dynamic_items import (
+            ReminderListAddButton,
+            ReminderListItemButton,
+            ReminderListNextButton,
+            ReminderListOptionsButton,
+            ReminderListPrevButton,
+        )
+
         self.clear_items()
+        if self.session_id is None:
+            return
 
         for slot_index in range(self.page_size):
             display_index = slot_index + 1
             job = self._page_item(slot_index)
-            job_id = str(job.id) if job is not None else ""
-
-            info_button = discord.ui.Button(
-                label=str(display_index),
-                style=discord.ButtonStyle.secondary,
-                custom_id=f"reminder_item_info:{job_id or display_index}",
-                row=0,
-                disabled=job is None,
+            self.add_item(
+                ReminderListItemButton(
+                    self.session_id,
+                    display_index,
+                    disabled=job is None,
+                )
             )
 
-            async def _info_callback(
-                interaction: discord.Interaction,
-                job_data: Optional[DailyJob] = job,
-            ) -> None:
-                await self._open_reminder_details(interaction, job_data)
-
-            info_button.callback = _info_callback
-            self.add_item(info_button)
+        self.add_item(
+            ReminderListPrevButton(
+                self.session_id,
+                disabled=self.page <= 1,
+            )
+        )
+        self.add_item(
+            ReminderListNextButton(
+                self.session_id,
+                disabled=self.page >= self.total_pages,
+            )
+        )
+        self.add_item(ReminderListAddButton(self.session_id))
+        self.add_item(
+            ReminderListOptionsButton(
+                self.session_id,
+                active=self._has_active_list_options(),
+            )
+        )
+        return
 
         prev_button = discord.ui.Button(
             style=discord.ButtonStyle.secondary,

--- a/views/ReminderOutputView.py
+++ b/views/ReminderOutputView.py
@@ -6,11 +6,8 @@ import discord
 
 from classes.DailyJob import DailyJob
 from classes.ReminderFunctions import ReminderFunctions
-from services.discord_helpers import (
-    format_reminder_mentions,
-)
+from services.discord_helpers import format_reminder_mentions
 from services.error_reporting import ValidationError, handle_interaction_error
-from services.reminder_destination import build_reminder_destination_select_options
 
 
 class ReminderDeleteConfirmModal(discord.ui.Modal):
@@ -36,13 +33,16 @@ class ReminderOutputView(discord.ui.View):
     def __init__(
         self,
         *,
-        job: DailyJob,
+        job: Optional[DailyJob],
         guild: Optional[discord.Guild],
         result_message: str,
         ok: bool = True,
         user_id: Optional[int] = None,
         response_ephemeral: bool = False,
-        timeout: float = 3600,
+        job_id: Optional[str] = None,
+        guild_id: Optional[int] = None,
+        channel_id: Optional[int] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.job: Optional[DailyJob] = job
@@ -52,10 +52,15 @@ class ReminderOutputView(discord.ui.View):
         self.user_id = user_id
         self.response_ephemeral = bool(response_ephemeral)
         self.message: Optional[discord.Message] = None
-        self.job_id = str(job.id)
-        self.guild_id = job.guild_id
-        self.channel_id = job.channel_id
-        self._sync_button_state()
+
+        resolved_job_id = str(job.id) if job is not None else str(job_id or "").strip()
+        if not resolved_job_id:
+            raise ValueError("ReminderOutputView needs a reminder id.")
+
+        self.job_id = resolved_job_id
+        self.guild_id = job.guild_id if job is not None else guild_id
+        self.channel_id = job.channel_id if job is not None else channel_id
+        self._rebuild_items()
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if self.user_id is None or interaction.user.id == self.user_id:
@@ -74,7 +79,7 @@ class ReminderOutputView(discord.ui.View):
         )
         if self.job is not None:
             self.channel_id = self.job.channel_id
-        self._sync_button_state()
+        self._rebuild_items()
 
     async def refresh_message(
         self,
@@ -123,27 +128,60 @@ class ReminderOutputView(discord.ui.View):
 
         return False
 
-    def _sync_button_state(self) -> None:
+    def _rebuild_items(self) -> None:
+        from views.reminder_dynamic_items import (
+            ReminderAddButton,
+            ReminderDeleteButton,
+            ReminderEditButton,
+            ReminderPingButton,
+            ReminderToggleButton,
+        )
+
+        self.clear_items()
         has_job = self.job is not None
-        self.edit_this_reminder.disabled = not has_job
-        self.edit_ping_users.disabled = not has_job
-        self.toggle_state.disabled = not has_job
-        self.delete_reminder.disabled = not has_job
+        encoded_user_id = int(self.user_id or 0)
+        is_paused = has_job and ReminderFunctions.is_paused(self.job)
 
-        if not has_job:
-            self.toggle_state.label = None
-            self.toggle_state.emoji = "🚫"
-            self.toggle_state.style = discord.ButtonStyle.secondary
-            return
-
-        if ReminderFunctions.is_paused(self.job):
-            self.toggle_state.label = None
-            self.toggle_state.emoji = "▶️"
-            self.toggle_state.style = discord.ButtonStyle.success
-        else:
-            self.toggle_state.label = None
-            self.toggle_state.emoji = "⏸️"
-            self.toggle_state.style = discord.ButtonStyle.secondary
+        self.add_item(
+            ReminderAddButton(
+                self.job_id,
+                encoded_user_id,
+                self.response_ephemeral,
+            )
+        )
+        self.add_item(
+            ReminderEditButton(
+                self.job_id,
+                encoded_user_id,
+                self.response_ephemeral,
+                disabled=not has_job,
+            )
+        )
+        self.add_item(
+            ReminderPingButton(
+                self.job_id,
+                encoded_user_id,
+                self.response_ephemeral,
+                disabled=not has_job,
+            )
+        )
+        self.add_item(
+            ReminderToggleButton(
+                self.job_id,
+                encoded_user_id,
+                self.response_ephemeral,
+                paused=bool(is_paused),
+                disabled=not has_job,
+            )
+        )
+        self.add_item(
+            ReminderDeleteButton(
+                self.job_id,
+                encoded_user_id,
+                self.response_ephemeral,
+                disabled=not has_job,
+            )
+        )
 
     @staticmethod
     def _format_channel(job: Optional[DailyJob], channel_id: Optional[int]) -> str:
@@ -302,204 +340,6 @@ class ReminderOutputView(discord.ui.View):
             payload["view"] = self
         return payload
 
-    @discord.ui.button(
-        emoji="➕",
-        style=discord.ButtonStyle.success,
-        row=0,
-    )
-    async def add_new_reminder(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        from views.ReminderEditModal import (
-            ReminderCreateModal,
-        )
-
-        self.message = interaction.message
-        default_channel_id = self.channel_id or interaction.channel_id
-        await interaction.response.send_modal(
-            ReminderCreateModal(
-                parent_view=self,
-                default_channel_id=default_channel_id,
-                default_destination_type=(
-                    "private"
-                    if self.job is not None
-                    and ReminderFunctions.is_private_destination(self.job)
-                    else "channel"
-                ),
-                guild=interaction.guild or self.guild,
-                source_message=interaction.message,
-                response_ephemeral=self.response_ephemeral,
-            )
-        )
-
-    @discord.ui.button(
-        emoji="✏️",
-        style=discord.ButtonStyle.secondary,
-        row=0,
-    )
-    async def edit_this_reminder(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        from views.ReminderEditModal import (
-            ReminderEditModal,
-        )
-
-        self.message = interaction.message
-        if self.job is None:
-            await interaction.response.send_message(
-                "That reminder is no longer available.",
-                ephemeral=self.response_ephemeral,
-            )
-            return
-
-        channel_options = build_reminder_destination_select_options(
-            interaction.guild,
-            self.job.channel_id,
-            is_private_selected=ReminderFunctions.is_private_destination(self.job),
-        )
-        await interaction.response.send_modal(
-            ReminderEditModal(
-                self.job,
-                channel_options=channel_options,
-                parent_view=self,
-                source_message=interaction.message,
-                response_ephemeral=self.response_ephemeral,
-            )
-        )
-
-    @discord.ui.button(
-        emoji="🔔",
-        style=discord.ButtonStyle.primary,
-        row=0,
-    )
-    async def edit_ping_users(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        from views.ReminderEditModal import (
-            ReminderPingModal,
-        )
-
-        self.message = interaction.message
-        if self.job is None:
-            await interaction.response.send_message(
-                "That reminder is no longer available.",
-                ephemeral=self.response_ephemeral,
-            )
-            return
-
-        await interaction.response.send_modal(
-            ReminderPingModal(
-                guild=interaction.guild or self.guild,
-                guild_id=self.guild_id,
-                default_channel_id=self.channel_id or interaction.channel_id,
-                response_ephemeral=self.response_ephemeral,
-                user_id=interaction.user.id,
-                job=self.job,
-                parent_view=self,
-                source_message=interaction.message,
-            )
-        )
-
-    @discord.ui.button(
-        emoji="⏸️",
-        style=discord.ButtonStyle.secondary,
-        row=0,
-    )
-    async def toggle_state(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        if self.job is None:
-            await interaction.response.send_message(
-                "That reminder is no longer available.",
-                ephemeral=self.response_ephemeral,
-            )
-            return
-
-        await interaction.response.defer(ephemeral=self.response_ephemeral)
-
-        try:
-            if ReminderFunctions.is_paused(self.job):
-                result = await asyncio.to_thread(
-                    ReminderFunctions.resume_reminder,
-                    self.job_id,
-                    self.guild_id,
-                )
-                desired_message = f"Resumed reminder `{self.job_id}`."
-                no_change_message = f"Reminder `{self.job_id}` is already active."
-            else:
-                result = await asyncio.to_thread(
-                    ReminderFunctions.pause_reminder,
-                    self.job_id,
-                    self.guild_id,
-                )
-                desired_message = f"Paused reminder `{self.job_id}`."
-                no_change_message = f"Reminder `{self.job_id}` is already paused."
-        except ValueError as exc:
-            await handle_interaction_error(
-                interaction,
-                ValidationError(
-                    "That reminder ID is invalid.",
-                    ephemeral=self.response_ephemeral,
-                    cause=exc,
-                ),
-                ephemeral=self.response_ephemeral,
-            )
-            return
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                exc,
-                ephemeral=self.response_ephemeral,
-            )
-            return
-
-        if result == "missing":
-            self.result_message = "This reminder is no longer available."
-            self.ok = False
-            await self.refresh_message(
-                interaction,
-                source_message=interaction.message,
-                result_message=self.result_message,
-            )
-            return
-
-        result_message = no_change_message if "already_" in result else desired_message
-        self.ok = True
-        await self.refresh_message(
-            interaction,
-            source_message=interaction.message,
-            result_message=result_message,
-        )
-
-    @discord.ui.button(
-        emoji="🗑️",
-        style=discord.ButtonStyle.danger,
-        row=0,
-    )
-    async def delete_reminder(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        if self.job is None:
-            await interaction.response.send_message(
-                "That reminder is no longer available.",
-                ephemeral=self.response_ephemeral,
-            )
-            return
-
-        await interaction.response.send_modal(ReminderDeleteConfirmModal(self))
-
     async def _confirm_delete(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=self.response_ephemeral)
         try:
@@ -531,7 +371,7 @@ class ReminderOutputView(discord.ui.View):
             self.job = None
             self.ok = False
             self.result_message = "This reminder is no longer available."
-            self._sync_button_state()
+            self._rebuild_items()
             await self.refresh_message(
                 interaction,
                 source_message=interaction.message,
@@ -546,7 +386,7 @@ class ReminderOutputView(discord.ui.View):
         self.job = None
         self.ok = True
         self.result_message = f"Deleted reminder `{self.job_id}`."
-        self._sync_button_state()
+        self._rebuild_items()
         await self.refresh_message(
             interaction,
             source_message=interaction.message,

--- a/views/ScheduledJobActionView.py
+++ b/views/ScheduledJobActionView.py
@@ -18,9 +18,6 @@ from services.error_reporting import ValidationError, handle_interaction_error
 from services.schedule_time import schedule_timezone_name
 from services.timezone_gate import ensure_user_timezone
 
-_MODAL_SELECTS_SUPPORTED = True
-
-
 def _schedule_expression(schedule: Optional[Mapping[str, Any]]) -> str:
     if not isinstance(schedule, Mapping):
         return ""
@@ -453,6 +450,7 @@ class ScheduledJobChangeChannelModal(discord.ui.Modal, title="Change Job Channel
             return
 
         self._view.channel_id = new_channel_id
+        await self._view.refresh_message()
         await interaction.followup.send(
             f"Updated job `{self._view.job_id}` to post in <#{new_channel_id}>.",
             ephemeral=self._view.response_ephemeral,
@@ -467,7 +465,7 @@ class ScheduledJobActionView(discord.ui.View):
         channel_id: Optional[int],
         guild_id: Optional[int],
         response_ephemeral: bool = True,
-        timeout: float = 3600,
+        timeout: float | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.job_id = str(job_id)
@@ -475,8 +473,11 @@ class ScheduledJobActionView(discord.ui.View):
         self.guild_id = guild_id
         self.response_ephemeral = bool(response_ephemeral)
         self.job: Optional[DailyJob] = None
+        self.message: Optional[discord.Message] = None
+        self._rebuild_items()
 
-    async def _load_job(self, manager: DailyJobManager) -> Optional[DailyJob]:
+    async def load_job(self) -> Optional[DailyJob]:
+        manager = DailyJobManager()
         self.job = await asyncio.to_thread(
             manager.get_job,
             self.job_id,
@@ -485,176 +486,56 @@ class ScheduledJobActionView(discord.ui.View):
         )
         return self.job
 
-    @discord.ui.button(label="Run now", style=discord.ButtonStyle.success)
-    async def run_now(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await interaction.response.defer(ephemeral=self.response_ephemeral)
-        manager = DailyJobManager()
-        try:
-            job = await self._load_job(manager)
-            if job is None:
-                raise ValidationError(
-                    "That job no longer exists in this channel.",
-                    ephemeral=self.response_ephemeral,
-                )
+    def _rebuild_items(self, *, disabled: bool = False) -> None:
+        from views.scheduled_job_dynamic_items import (
+            ScheduledJobChangeChannelButton,
+            ScheduledJobDeleteButton,
+            ScheduledJobEditButton,
+            ScheduledJobRunNowButton,
+        )
 
-            if job.type not in {"message", "crypto", "stock"}:
-                raise ValidationError(
-                    "Run now is currently supported for message, crypto, and stock jobs.",
-                    ephemeral=self.response_ephemeral,
-                )
-
-            payload = await asyncio.to_thread(job.run)
-            if not payload:
-                raise ValidationError(
-                    "This job did not produce any output to send.",
-                    ephemeral=self.response_ephemeral,
-                )
-
-            bot = interaction.client
-            if not isinstance(bot, commands.Bot):
-                raise ValidationError(
-                    "Bot is not ready to send this job.",
-                    ephemeral=self.response_ephemeral,
-                )
-
-            channel = await resolve_messageable_channel(bot, job.channel_id)
-            if channel is None:
-                raise ValidationError(
-                    "I can't access the destination channel for this job.",
-                    ephemeral=self.response_ephemeral,
-                )
-
-            await channel.send(**payload)
-            await interaction.followup.send(
-                f"Ran job `{self.job_id}` now in <#{job.channel_id}>.",
-                ephemeral=self.response_ephemeral,
-            )
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                exc,
-                ephemeral=self.response_ephemeral,
-            )
-
-    @discord.ui.button(label="Edit", style=discord.ButtonStyle.secondary)
-    async def edit(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        manager = DailyJobManager()
-        try:
-            job = await self._load_job(manager)
-            if job is None:
-                raise ValidationError(
-                    "That job no longer exists in this channel.",
-                    ephemeral=self.response_ephemeral,
-                )
-            if job.type not in {"message", "crypto", "stock"}:
-                raise ValidationError(
-                    "Editing is currently supported for message, crypto, and stock jobs.",
-                    ephemeral=self.response_ephemeral,
-                )
-            await interaction.response.send_modal(
-                ScheduledJobEditModal(
-                    self,
-                    job,
-                    source_message=interaction.message,
-                )
-            )
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                exc,
-                ephemeral=self.response_ephemeral,
-            )
-
-    @discord.ui.button(label="Change Channel", style=discord.ButtonStyle.primary)
-    async def change_channel(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        global _MODAL_SELECTS_SUPPORTED
-        try:
-            manager = DailyJobManager()
-            job = await self._load_job(manager)
-            if job is None:
-                raise ValidationError(
-                    "That job no longer exists in this channel.",
-                    ephemeral=self.response_ephemeral,
-                )
-
-            channel_options = _build_channel_select_options(
-                interaction, self.channel_id
-            )
-            if _MODAL_SELECTS_SUPPORTED:
-                try:
-                    await interaction.response.send_modal(
-                        ScheduledJobChangeChannelModal(
-                            self,
-                            channel_options=channel_options,
-                        )
-                    )
-                    return
-                except discord.HTTPException as exc:
-                    if exc.code == 50035 and "must be one of (4,)" in str(exc):
-                        _MODAL_SELECTS_SUPPORTED = False
-                    else:
-                        raise
-
-            await interaction.response.send_modal(ScheduledJobChangeChannelModal(self))
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                exc,
-                ephemeral=self.response_ephemeral,
-            )
-
-    @discord.ui.button(label="Delete", style=discord.ButtonStyle.danger)
-    async def delete(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await interaction.response.defer()
-        manager = DailyJobManager()
-        try:
-            deleted = await asyncio.to_thread(
-                manager.delete_job,
+        self.clear_items()
+        self.add_item(
+            ScheduledJobRunNowButton(
                 self.job_id,
                 self.channel_id,
                 self.guild_id,
+                self.response_ephemeral,
+                disabled=disabled,
             )
-            if not deleted:
-                raise ValidationError(
-                    "That job no longer exists in this channel.",
-                    ephemeral=self.response_ephemeral,
-                )
-
-            for child in self.children:
-                child.disabled = True
-
-            if interaction.message is not None:
-                try:
-                    await interaction.message.edit(view=self)
-                except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-                    pass
-
-            await interaction.followup.send(
-                ephemeral=False,
-                **DailyTaskEmbeds.jobs_cancel_embed(
-                    f"Deleted job `{self.job_id}`.",
-                    ok=True,
-                ),
+        )
+        self.add_item(
+            ScheduledJobEditButton(
+                self.job_id,
+                self.channel_id,
+                self.guild_id,
+                self.response_ephemeral,
+                disabled=disabled,
             )
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                exc,
-                ephemeral=self.response_ephemeral,
+        )
+        self.add_item(
+            ScheduledJobChangeChannelButton(
+                self.job_id,
+                self.channel_id,
+                self.guild_id,
+                self.response_ephemeral,
+                disabled=disabled,
             )
+        )
+        self.add_item(
+            ScheduledJobDeleteButton(
+                self.job_id,
+                self.channel_id,
+                self.guild_id,
+                self.response_ephemeral,
+                disabled=disabled,
+            )
+        )
+
+    async def refresh_message(self, **payload: Any) -> None:
+        if self.message is None:
+            return
+        try:
+            await self.message.edit(view=self, **payload)
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            return

--- a/views/StockActionView.py
+++ b/views/StockActionView.py
@@ -375,16 +375,34 @@ class StockDailyJobModal(discord.ui.Modal, title="Schedule Daily Stock Check"):
 
 
 class StockActionView(discord.ui.View):
-    def __init__(self, symbol: str, *, timeout: float = 3600) -> None:
+    def __init__(self, symbol: str, *, timeout: float | None = None) -> None:
         super().__init__(timeout=timeout)
         self.symbol = symbol.strip().upper()
+        self._build()
 
-    @discord.ui.button(label="Set Alert", style=discord.ButtonStyle.success)
-    async def set_alert(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
+    def _build(self) -> None:
+        self.clear_items()
+
+        from views.stock_action_dynamic_items import (
+            StockScheduleDailyCheckButton,
+            StockSetAlertButton,
+        )
+
+        symbol = self.symbol
+        self.add_item(
+            StockSetAlertButton(
+                symbol=symbol,
+                disabled=not bool(symbol),
+            )
+        )
+        self.add_item(
+            StockScheduleDailyCheckButton(
+                symbol=symbol,
+                disabled=not bool(symbol),
+            )
+        )
+
+    async def open_set_alert_modal(self, interaction: discord.Interaction) -> None:
         if not self.symbol:
             await handle_interaction_error(
                 interaction,
@@ -395,13 +413,9 @@ class StockActionView(discord.ui.View):
             return
         await interaction.response.send_modal(StockAlertModal(self.symbol))
 
-    @discord.ui.button(
-        label="Schedule Daily Check", style=discord.ButtonStyle.secondary
-    )
-    async def schedule_daily_check(
+    async def open_schedule_daily_check_modal(
         self,
         interaction: discord.Interaction,
-        _: discord.ui.Button,
     ) -> None:
         if not self.symbol:
             await handle_interaction_error(

--- a/views/StockAlertActionView.py
+++ b/views/StockAlertActionView.py
@@ -6,9 +6,7 @@ import discord
 
 from classes.OpenAIFunctions import OpenAIFunctions
 from classes.PriceAlertFunctions import (
-    deactivate_alert,
     fetch_user_alert_by_id,
-    set_alert_paused,
     update_alert,
 )
 from classes.UserSettingsFunctions import UserSettingsFunctions
@@ -211,7 +209,7 @@ class StockAlertActionView(discord.ui.View):
         alert_id: str,
         user_id: int,
         guild_id: Optional[int],
-        timeout: float = 900,
+        timeout: float | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.alert_id = str(alert_id)
@@ -219,6 +217,7 @@ class StockAlertActionView(discord.ui.View):
         self.guild_id = guild_id
         self.alert: Optional[Dict[str, Any]] = None
         self.message: Optional[discord.Message] = None
+        self._rebuild_items()
 
     @staticmethod
     def _target_label(value: Any, currency: str) -> str:
@@ -237,7 +236,6 @@ class StockAlertActionView(discord.ui.View):
 
     async def initialize(self) -> None:
         await self.refresh_state()
-        self._sync_button_state()
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id == self.user_id:
@@ -257,21 +255,44 @@ class StockAlertActionView(discord.ui.View):
             self.guild_id,
             True,
         )
-        self._sync_button_state()
+        self._rebuild_items()
 
-    def _sync_button_state(self) -> None:
+    def _rebuild_items(self) -> None:
+        from views.stock_alert_dynamic_items import (
+            StockAlertDeleteButton,
+            StockAlertEditButton,
+            StockAlertToggleButton,
+        )
+
         has_alert = self.alert is not None
-        self.edit_alert_button.disabled = not has_alert
-        self.pause_resume_button.disabled = not has_alert
-        self.delete_button.disabled = not has_alert
-
         paused = bool((self.alert or {}).get("paused"))
-        if paused:
-            self.pause_resume_button.label = "Resume"
-            self.pause_resume_button.style = discord.ButtonStyle.success
-        else:
-            self.pause_resume_button.label = "Pause"
-            self.pause_resume_button.style = discord.ButtonStyle.secondary
+
+        self.clear_items()
+        self.add_item(
+            StockAlertEditButton(
+                self.alert_id,
+                self.user_id,
+                self.guild_id,
+                disabled=not has_alert,
+            )
+        )
+        self.add_item(
+            StockAlertToggleButton(
+                self.alert_id,
+                self.user_id,
+                self.guild_id,
+                paused=paused,
+                disabled=not has_alert,
+            )
+        )
+        self.add_item(
+            StockAlertDeleteButton(
+                self.alert_id,
+                self.user_id,
+                self.guild_id,
+                disabled=not has_alert,
+            )
+        )
 
     def payload(self) -> dict:
         embed = discord.Embed(
@@ -320,88 +341,3 @@ class StockAlertActionView(discord.ui.View):
             await self.message.edit(view=self, **self.payload())
         except (discord.NotFound, discord.Forbidden, discord.HTTPException):
             return
-
-    @discord.ui.button(label="Edit", style=discord.ButtonStyle.primary, row=0)
-    async def edit_alert_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        if self.alert is None:
-            await interaction.response.send_message(
-                ephemeral=True,
-                content="That alert is no longer active.",
-            )
-            return
-
-        await interaction.response.send_modal(StockAlertEditModal(self, self.alert))
-
-    @discord.ui.button(label="Pause", style=discord.ButtonStyle.secondary, row=0)
-    async def pause_resume_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        await interaction.response.defer(ephemeral=True)
-
-        if self.alert is None:
-            await interaction.followup.send(
-                ephemeral=True,
-                content="That alert is no longer active.",
-            )
-            return
-
-        currently_paused = bool(self.alert.get("paused"))
-        changed = await asyncio.to_thread(
-            set_alert_paused,
-            self.alert_id,
-            self.user_id,
-            not currently_paused,
-            asset_type="stock",
-            guild_id=self.guild_id,
-        )
-        if not changed:
-            await interaction.followup.send(
-                ephemeral=True,
-                content="That alert could not be updated.",
-            )
-            return
-
-        await self.refresh_state()
-        await self.refresh_message()
-        await interaction.followup.send(
-            ephemeral=True,
-            content="Alert resumed." if currently_paused else "Alert paused.",
-        )
-
-    @discord.ui.button(label="Delete", style=discord.ButtonStyle.danger, row=0)
-    async def delete_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        await interaction.response.defer(ephemeral=True)
-
-        deleted = await asyncio.to_thread(
-            deactivate_alert,
-            self.alert_id,
-            self.user_id,
-            "stock",
-            self.guild_id,
-        )
-        if not deleted:
-            await interaction.followup.send(
-                ephemeral=True,
-                content="That alert was not found.",
-            )
-            return
-
-        await self.refresh_state()
-        await self.refresh_message()
-        await interaction.followup.send(
-            ephemeral=True,
-            content="Alert deleted.",
-        )

--- a/views/StockListItemsView.py
+++ b/views/StockListItemsView.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import discord
 
 from classes.DailyJobManager import DailyJobManager
-from classes.PriceAlertFunctions import deactivate_alert, fetch_user_active_alerts
-from services.error_reporting import handle_interaction_error
+from classes.PriceAlertFunctions import fetch_user_active_alerts
+from services import stock_list_sessions
 from views.ScheduledJobActionView import ScheduledJobActionView
 from views.StockAlertActionView import StockAlertActionView
 
@@ -22,25 +22,101 @@ class StockListItemsView(discord.ui.View):
         guild_id: Optional[int],
         channel_id: Optional[int],
         kind: str = "all",
-        timeout: float = 900,
+        page: int = 1,
+        session_id: Optional[str] = None,
+        selected_entry_type: str = "",
+        selected_entry_id: str = "",
+        timeout: float | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.user_id = user_id
         self.guild_id = guild_id
         self.channel_id = channel_id
         self.kind = kind if kind in {"all", "schedules", "alerts"} else "all"
+        self.session_id = str(session_id or "").strip() or None
+        self.message: Optional[discord.Message] = None
 
         self.entries: List[Dict[str, Any]] = []
         self.schedule_count = 0
         self.alert_count = 0
 
-        self.page = 1
+        self.page = max(1, int(page or 1))
         self.total_pages = 1
         self.selected_index = 0
+        self._selected_entry_type = str(selected_entry_type or "").strip()
+        self._selected_entry_id = str(selected_entry_id or "").strip()
 
     async def initialize(self) -> None:
         await self._reload_entries()
-        self._sync_button_state()
+        await self.ensure_session()
+
+    @classmethod
+    async def from_session(
+        cls,
+        interaction: discord.Interaction,
+        session_id: str,
+    ) -> Optional["StockListItemsView"]:
+        session = await asyncio.to_thread(
+            stock_list_sessions.get_session,
+            session_id,
+        )
+        if session is None:
+            return None
+
+        view = cls(
+            user_id=int(session.get("user_id") or 0),
+            guild_id=session.get("guild_id"),
+            channel_id=session.get("channel_id"),
+            kind=str(session.get("kind") or "all"),
+            page=max(1, int(session.get("page") or 1)),
+            session_id=str(session.get("session_id") or session_id).strip(),
+            selected_entry_type=str(session.get("selected_entry_type") or ""),
+            selected_entry_id=str(session.get("selected_entry_id") or ""),
+        )
+        view.message = interaction.message
+        await view.initialize()
+        return view
+
+    async def ensure_session(self) -> str:
+        if self.session_id is None:
+            self.session_id = await asyncio.to_thread(
+                stock_list_sessions.create_session,
+                self.session_state(),
+            )
+        else:
+            await self.save_session()
+        self._build()
+        return self.session_id
+
+    async def save_session(self) -> None:
+        if self.session_id is None:
+            return
+        await asyncio.to_thread(
+            stock_list_sessions.save_session,
+            self.session_id,
+            self.session_state(),
+        )
+
+    def session_state(self) -> dict:
+        selected = self._selected_entry()
+        selected_entry_type = self._selected_entry_type
+        selected_entry_id = self._selected_entry_id
+        if selected is not None:
+            selected_entry_type = str(selected.get("entry_type") or "").strip()
+            if selected_entry_type == "schedule":
+                selected_entry_id = str(selected.get("job_id") or "").strip()
+            else:
+                selected_entry_id = str(selected.get("alert_id") or "").strip()
+
+        return {
+            "user_id": self.user_id,
+            "guild_id": self.guild_id,
+            "channel_id": self.channel_id,
+            "kind": self.kind,
+            "page": self.page,
+            "selected_entry_type": selected_entry_type,
+            "selected_entry_id": selected_entry_id,
+        }
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id == self.user_id:
@@ -57,6 +133,14 @@ class StockListItemsView(discord.ui.View):
         if entry_type == "schedule":
             return entry_type, str(entry.get("job_id") or "")
         return entry_type, str(entry.get("alert_id") or "")
+
+    def _selected_key(self) -> Optional[Tuple[str, str]]:
+        selected = self._selected_entry()
+        if selected is not None:
+            return self._entry_key(selected)
+        if self._selected_entry_type and self._selected_entry_id:
+            return self._selected_entry_type, self._selected_entry_id
+        return None
 
     @staticmethod
     def _truncate(text: str, limit: int) -> str:
@@ -99,10 +183,7 @@ class StockListItemsView(discord.ui.View):
         return value[:8]
 
     async def _reload_entries(self) -> None:
-        previous_key: Optional[Tuple[str, str]] = None
-        if self.entries and 0 <= self.selected_index < len(self.entries):
-            previous_key = self._entry_key(self.entries[self.selected_index])
-
+        previous_key = self._selected_key()
         schedules: List[Dict[str, Any]] = []
         alerts: List[Dict[str, Any]] = []
 
@@ -167,7 +248,12 @@ class StockListItemsView(discord.ui.View):
             self.selected_index = 0
             self.page = 1
             self.total_pages = 1
+            self._selected_entry_type = ""
+            self._selected_entry_id = ""
             return
+
+        self.total_pages = max(1, math.ceil(len(self.entries) / self.PAGE_SIZE))
+        self.page = max(1, min(self.page, self.total_pages))
 
         selected_index = None
         if previous_key is not None:
@@ -177,11 +263,19 @@ class StockListItemsView(discord.ui.View):
                     break
 
         if selected_index is None:
-            selected_index = max(0, min(self.selected_index, len(self.entries) - 1))
+            page_start = (self.page - 1) * self.PAGE_SIZE
+            selected_index = min(page_start, len(self.entries) - 1)
 
         self.selected_index = selected_index
-        self.total_pages = max(1, math.ceil(len(self.entries) / self.PAGE_SIZE))
         self.page = (self.selected_index // self.PAGE_SIZE) + 1
+        selected = self._selected_entry()
+        if selected is None:
+            self._selected_entry_type = ""
+            self._selected_entry_id = ""
+        else:
+            self._selected_entry_type, self._selected_entry_id = self._entry_key(
+                selected
+            )
 
     def _summary_text(self) -> str:
         scope_line = "Schedules are scoped to this channel."
@@ -209,11 +303,15 @@ class StockListItemsView(discord.ui.View):
         return self.entries[self.selected_index]
 
     def _schedule_line(
-        self, display_index: int, entry: Dict[str, Any], selected: bool
+        self,
+        display_index: int,
+        entry: Dict[str, Any],
+        selected: bool,
     ) -> str:
         ticker = self._truncate(str(entry.get("ticker") or "UNKNOWN"), 10)
         schedule_value = self._truncate(
-            self._schedule_core(entry.get("schedule") or {}), 28
+            self._schedule_core(entry.get("schedule") or {}),
+            28,
         )
         channel_id = entry.get("channel_id")
         channel_value = f"<#{channel_id}>" if channel_id else "unknown"
@@ -226,7 +324,10 @@ class StockListItemsView(discord.ui.View):
         )
 
     def _alert_line(
-        self, display_index: int, entry: Dict[str, Any], selected: bool
+        self,
+        display_index: int,
+        entry: Dict[str, Any],
+        selected: bool,
     ) -> str:
         symbol = self._truncate(str(entry.get("symbol") or "UNKNOWN"), 10)
         trigger = self._truncate(
@@ -339,122 +440,87 @@ class StockListItemsView(discord.ui.View):
         if absolute_index < 0 or absolute_index >= len(self.entries):
             return
         self.selected_index = absolute_index
+        selected = self._selected_entry()
+        if selected is None:
+            self._selected_entry_type = ""
+            self._selected_entry_id = ""
+            return
+        self._selected_entry_type, self._selected_entry_id = self._entry_key(selected)
 
-    def _sync_button_state(self) -> None:
-        has_entries = len(self.entries) > 0
-        self.total_pages = (
-            max(1, math.ceil(len(self.entries) / self.PAGE_SIZE)) if has_entries else 1
+    def _build(self) -> None:
+        self.clear_items()
+        if self.session_id is None:
+            return
+
+        from views.stock_list_dynamic_items import (
+            StockListDeleteButton,
+            StockListManageButton,
+            StockListNextButton,
+            StockListPrevButton,
+            StockListRefreshButton,
+            StockListSelectButton,
         )
-        self.page = max(1, min(self.page, self.total_pages))
 
-        page_entries = self._page_slice() if has_entries else []
+        page_entries = self._page_slice()
         page_start = (self.page - 1) * self.PAGE_SIZE
-
-        selectors = [
-            self.select_1,
-            self.select_2,
-            self.select_3,
-            self.select_4,
-            self.select_5,
-        ]
-        for idx, button in enumerate(selectors):
+        for idx in range(self.PAGE_SIZE):
             has_item = idx < len(page_entries)
-            button.disabled = not has_item
-            button.label = str(idx + 1)
-            if not has_item:
-                button.style = discord.ButtonStyle.secondary
-                continue
-            absolute_index = page_start + idx
-            button.style = (
-                discord.ButtonStyle.primary
-                if absolute_index == self.selected_index
-                else discord.ButtonStyle.secondary
+            selected = has_item and page_start + idx == self.selected_index
+            self.add_item(
+                StockListSelectButton(
+                    self.session_id,
+                    idx,
+                    disabled=not has_item,
+                    selected=selected,
+                )
             )
 
-        self.prev_page.disabled = (not has_entries) or self.page <= 1
-        self.next_page.disabled = (not has_entries) or self.page >= self.total_pages
-        self.manage_item.disabled = not has_entries
-        self.delete_item.disabled = not has_entries
+        has_entries = bool(self.entries)
+        self.add_item(
+            StockListPrevButton(
+                self.session_id,
+                disabled=(not has_entries) or self.page <= 1,
+            )
+        )
+        self.add_item(
+            StockListNextButton(
+                self.session_id,
+                disabled=(not has_entries) or self.page >= self.total_pages,
+            )
+        )
+        self.add_item(
+            StockListRefreshButton(
+                self.session_id,
+                disabled=not has_entries,
+            )
+        )
+        self.add_item(
+            StockListManageButton(
+                self.session_id,
+                disabled=not has_entries,
+            )
+        )
+        self.add_item(
+            StockListDeleteButton(
+                self.session_id,
+                disabled=not has_entries,
+            )
+        )
 
-    async def _refresh_message(self, interaction: discord.Interaction) -> None:
-        self._sync_button_state()
+    async def refresh_message(self, interaction: discord.Interaction) -> None:
+        self._build()
+        await self.save_session()
         if interaction.response.is_done():
+            if interaction.message is not None:
+                await interaction.message.edit(view=self, **self.payload())
+                return
             await interaction.edit_original_response(view=self, **self.payload())
-        else:
-            await interaction.response.edit_message(view=self, **self.payload())
-
-    @discord.ui.button(label="1", style=discord.ButtonStyle.secondary, row=0)
-    async def select_1(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        self._select_index(0)
-        await self._refresh_message(interaction)
-
-    @discord.ui.button(label="2", style=discord.ButtonStyle.secondary, row=0)
-    async def select_2(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        self._select_index(1)
-        await self._refresh_message(interaction)
-
-    @discord.ui.button(label="3", style=discord.ButtonStyle.secondary, row=0)
-    async def select_3(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        self._select_index(2)
-        await self._refresh_message(interaction)
-
-    @discord.ui.button(label="4", style=discord.ButtonStyle.secondary, row=0)
-    async def select_4(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        self._select_index(3)
-        await self._refresh_message(interaction)
-
-    @discord.ui.button(label="5", style=discord.ButtonStyle.secondary, row=0)
-    async def select_5(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        self._select_index(4)
-        await self._refresh_message(interaction)
-
-    @discord.ui.button(label="Prev", style=discord.ButtonStyle.secondary, row=1)
-    async def prev_page(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        if self.page <= 1:
-            await interaction.response.defer(ephemeral=True)
             return
-        self.page -= 1
-        self._select_index(0)
-        await self._refresh_message(interaction)
+        await interaction.response.edit_message(view=self, **self.payload())
 
-    @discord.ui.button(label="Next", style=discord.ButtonStyle.secondary, row=1)
-    async def next_page(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        if self.page >= self.total_pages:
-            await interaction.response.defer(ephemeral=True)
-            return
-        self.page += 1
-        self._select_index(0)
-        await self._refresh_message(interaction)
-
-    @discord.ui.button(label="Refresh", style=discord.ButtonStyle.secondary, row=1)
-    async def refresh_list(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        await interaction.response.defer()
-        await self._reload_entries()
-        self._sync_button_state()
-        if interaction.message is not None:
-            await interaction.message.edit(view=self, **self.payload())
-        else:
-            await interaction.edit_original_response(view=self, **self.payload())
-
-    @discord.ui.button(label="Manage", style=discord.ButtonStyle.primary, row=2)
-    async def manage_item(
-        self, interaction: discord.Interaction, _: discord.ui.Button
+    async def send_selected_item_actions(
+        self,
+        interaction: discord.Interaction,
     ) -> None:
         current = self._selected_entry()
         if current is None:
@@ -495,47 +561,3 @@ class StockListItemsView(discord.ui.View):
             ephemeral=True,
             content="No actions available for this item.",
         )
-
-    @discord.ui.button(label="Delete", style=discord.ButtonStyle.danger, row=2)
-    async def delete_item(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ) -> None:
-        current = self._selected_entry()
-        if current is None:
-            await interaction.response.send_message(
-                ephemeral=True,
-                content="No item selected.",
-            )
-            return
-
-        try:
-            if str(current.get("entry_type") or "") == "schedule":
-                manager = DailyJobManager()
-                deleted = await asyncio.to_thread(
-                    manager.delete_job,
-                    str(current.get("job_id") or ""),
-                    current.get("channel_id"),
-                    current.get("guild_id"),
-                )
-                message = "Schedule deleted." if deleted else "Schedule was not found."
-            else:
-                deleted = await asyncio.to_thread(
-                    deactivate_alert,
-                    str(current.get("alert_id") or ""),
-                    self.user_id,
-                    "stock",
-                    self.guild_id,
-                )
-                message = "Alert deleted." if deleted else "Alert was not found."
-        except Exception as exc:
-            await handle_interaction_error(interaction, exc, ephemeral=True)
-            return
-
-        await interaction.response.defer(ephemeral=True)
-        await self._reload_entries()
-        self._sync_button_state()
-        if interaction.message is not None:
-            await interaction.message.edit(view=self, **self.payload())
-        else:
-            await interaction.edit_original_response(view=self, **self.payload())
-        await interaction.followup.send(ephemeral=True, content=message)

--- a/views/TodoListDescriptionView.py
+++ b/views/TodoListDescriptionView.py
@@ -4,7 +4,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 import discord
 
 from classes.TodoFunctions import TodoFunctions
-from embeds.TodoEmbeds import TodoEmbeds, TodoListItemsView
+from embeds.TodoEmbeds import TodoEmbeds
 from services.error_reporting import (
     UserVisibleError,
     ValidationError,
@@ -88,13 +88,14 @@ class TodoListRenameModal(discord.ui.Modal):
             return
 
         self.parent_view.todo_list = updated_list
+        self.parent_view.list_id = str(updated_list.get("_id") or "").strip()
         self.parent_view.embed_title = "Todo List Updated"
         self.parent_view.embed_description = (
             f"Previous name: `{old_name}`\n"
             f"New name: `{updated_list.get('name') or 'List'}`"
         )
         self.parent_view.color = discord.Colour.blurple()
-        self.parent_view.sync_button_state()
+        self.parent_view._build()
         await self.parent_view.refresh_message(interaction)
 
 
@@ -107,16 +108,17 @@ class TodoListDescriptionView(discord.ui.View):
         color: Optional[discord.Colour] = None,
         todo_list: Optional[Dict[str, Any]] = None,
         user_id: Optional[int] = None,
-        timeout: float = 900,
+        timeout: float | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.embed_title = str(title or "").strip() or "Todo List"
         self.embed_description = str(description or "").strip()
         self.color = color or discord.Colour.blurple()
         self.todo_list = todo_list
+        self.list_id = str((todo_list or {}).get("_id") or "").strip()
         self.user_id = user_id
         self.message: Optional[discord.Message] = None
-        self.sync_button_state()
+        self._build()
 
     @property
     def list_name(self) -> str:
@@ -124,16 +126,57 @@ class TodoListDescriptionView(discord.ui.View):
             return "List"
         return TodoFunctions.display_list_name(self.todo_list, "List")
 
-    def sync_button_state(self) -> None:
+    def _build(self) -> None:
+        from views.todo_list_description_dynamic_items import (
+            TodoListAddButton,
+            TodoListClearButton,
+            TodoListDeleteButton,
+            TodoListRenameButton,
+            TodoListShowButton,
+        )
+
         has_list = bool(self.todo_list and self.todo_list.get("_id"))
         is_custom = has_list and (
             TodoFunctions.list_type(self.todo_list) == TodoFunctions._CUSTOM_LIST_TYPE
         )
-        self.show_list.disabled = not has_list
-        self.add_item.disabled = not has_list
-        self.rename_list.disabled = not is_custom
-        self.clear_list.disabled = not has_list
-        self.delete_list.disabled = not is_custom
+        encoded_user_id = int(self.user_id or 0)
+
+        self.clear_items()
+        self.add_item(
+            TodoListShowButton(
+                self.list_id,
+                encoded_user_id,
+                disabled=not has_list,
+            )
+        )
+        self.add_item(
+            TodoListAddButton(
+                self.list_id,
+                encoded_user_id,
+                disabled=not has_list,
+            )
+        )
+        self.add_item(
+            TodoListRenameButton(
+                self.list_id,
+                encoded_user_id,
+                disabled=not is_custom,
+            )
+        )
+        self.add_item(
+            TodoListClearButton(
+                self.list_id,
+                encoded_user_id,
+                disabled=not has_list,
+            )
+        )
+        self.add_item(
+            TodoListDeleteButton(
+                self.list_id,
+                encoded_user_id,
+                disabled=not is_custom,
+            )
+        )
 
     def payload(self) -> dict:
         return TodoEmbeds.list_description_embed(
@@ -158,19 +201,19 @@ class TodoListDescriptionView(discord.ui.View):
         return False
 
     async def refresh_todo_list(self) -> Optional[Dict[str, Any]]:
-        if not self.todo_list or not self.todo_list.get("_id"):
+        if not self.list_id:
             return None
 
         refreshed = await asyncio.to_thread(
             TodoFunctions.fetch_todo_list_by_id,
-            self.todo_list.get("_id"),
+            self.list_id,
         )
         self.todo_list = refreshed
-        self.sync_button_state()
+        self._build()
         return refreshed
 
     async def refresh_message(self, interaction: discord.Interaction) -> None:
-        self.sync_button_state()
+        self._build()
         try:
             if self.message is not None:
                 await self.message.edit(**self.response_payload())
@@ -282,188 +325,6 @@ class TodoListDescriptionView(discord.ui.View):
             f"Removed items: `{deleted_count}`"
         )
         self.color = discord.Colour.red()
-        self.sync_button_state()
+        self._build()
         self.stop()
         await self.refresh_message(interaction)
-
-    @discord.ui.button(emoji="📋", style=discord.ButtonStyle.secondary, row=0)
-    async def show_list(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        todo_list = await self.refresh_todo_list()
-        if todo_list is None:
-            await handle_interaction_error(
-                interaction,
-                ValidationError("That list is no longer available.", ephemeral=True),
-            )
-            return
-
-        try:
-            items = await asyncio.to_thread(
-                TodoFunctions.list_items_on_list,
-                todo_list.get("_id"),
-                "ascending",
-            )
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                UserVisibleError(
-                    "Something went wrong while loading that list.",
-                    ephemeral=True,
-                    cause=exc,
-                ),
-            )
-            return
-
-        view = TodoListItemsView(
-            todo_list=todo_list,
-            items=items,
-            sort="ascending",
-            status_filter="all",
-            user_id=interaction.user.id,
-            view_scope="list",
-            guild_id=interaction.guild_id,
-        )
-        await interaction.response.send_message(
-            ephemeral=True,
-            view=view,
-            **view.payload(),
-        )
-
-    @discord.ui.button(emoji="➕", style=discord.ButtonStyle.success, row=0)
-    async def add_item(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        todo_list = await self.refresh_todo_list()
-        if todo_list is None:
-            await handle_interaction_error(
-                interaction,
-                ValidationError("That list is no longer available.", ephemeral=True),
-            )
-            return
-
-        parent_view = TodoListItemsView(
-            todo_list=todo_list,
-            items=[],
-            sort="ascending",
-            status_filter="all",
-            user_id=interaction.user.id,
-            view_scope="list",
-            guild_id=interaction.guild_id,
-        )
-        await parent_view.open_create_modal(
-            interaction,
-            source_message=None,
-        )
-
-    @discord.ui.button(emoji="✏️", style=discord.ButtonStyle.primary, row=0)
-    async def rename_list(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        todo_list = await self.refresh_todo_list()
-        if todo_list is None:
-            await handle_interaction_error(
-                interaction,
-                ValidationError("That list is no longer available.", ephemeral=True),
-            )
-            return
-
-        await interaction.response.send_modal(TodoListRenameModal(self))
-
-    @discord.ui.button(emoji="🧹", style=discord.ButtonStyle.secondary, row=0)
-    async def clear_list(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        todo_list = await self.refresh_todo_list()
-        if todo_list is None:
-            await handle_interaction_error(
-                interaction,
-                ValidationError("That list is no longer available.", ephemeral=True),
-            )
-            return
-
-        try:
-            item_count = await asyncio.to_thread(
-                TodoFunctions.count_items_on_list,
-                todo_list.get("_id"),
-            )
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                UserVisibleError(
-                    "Something went wrong while preparing that confirmation.",
-                    ephemeral=True,
-                    cause=exc,
-                ),
-            )
-            return
-
-        description = self._format_confirmation_description(
-            action_text="This will remove every item from this list.",
-            list_name=TodoFunctions.display_list_name(todo_list, "List"),
-            item_count=item_count,
-        )
-        await interaction.response.send_modal(
-            TodoListConfirmModal(
-                title="Clear Todo List",
-                description=description,
-                on_confirm=self._run_clear_list,
-            )
-        )
-
-    @discord.ui.button(emoji="🗑️", style=discord.ButtonStyle.danger, row=0)
-    async def delete_list(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        todo_list = await self.refresh_todo_list()
-        if todo_list is None:
-            await handle_interaction_error(
-                interaction,
-                ValidationError("That list is no longer available.", ephemeral=True),
-            )
-            return
-
-        list_name = TodoFunctions.display_list_name(todo_list, "List")
-        try:
-            item_count = await asyncio.to_thread(
-                TodoFunctions.count_items_on_list,
-                todo_list.get("_id"),
-            )
-        except Exception as exc:
-            await handle_interaction_error(
-                interaction,
-                UserVisibleError(
-                    "Something went wrong while preparing that confirmation.",
-                    ephemeral=True,
-                    cause=exc,
-                ),
-            )
-            return
-
-        description = self._format_confirmation_description(
-            action_text="This will permanently delete this custom list.",
-            list_name=list_name,
-            item_count=item_count,
-        )
-        await interaction.response.send_modal(
-            TodoListConfirmModal(
-                title="Delete Todo List",
-                description=description,
-                on_confirm=self._run_delete_list,
-            )
-        )

--- a/views/TodoListDirectoryView.py
+++ b/views/TodoListDirectoryView.py
@@ -6,6 +6,7 @@ import discord
 
 from classes.TodoFunctions import TodoFunctions
 from embeds.TodoEmbeds import TodoEmbeds
+from services import todo_list_directory_sessions
 from services.error_reporting import (
     UserVisibleError,
     ValidationError,
@@ -111,7 +112,8 @@ class TodoListDirectoryView(discord.ui.View):
         page: int = 1,
         page_size: int = 5,
         sort_direction: str = "ascending",
-        timeout: float = 900,
+        session_id: Optional[str] = None,
+        timeout: float | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.current_scope = current_scope if current_scope == "personal" else "server"
@@ -123,6 +125,7 @@ class TodoListDirectoryView(discord.ui.View):
         self.sort_direction = (
             "descending" if sort_direction == "descending" else "ascending"
         )
+        self.session_id = str(session_id or "").strip() or None
         self.entries = [
             *[self._normalize_entry("Server", entry) for entry in server_lists],
             *[self._normalize_entry("Personal", entry) for entry in personal_lists],
@@ -131,7 +134,71 @@ class TodoListDirectoryView(discord.ui.View):
         self._sort_entries()
         self.total_pages = max(1, math.ceil(len(self.entries) / self.page_size))
         self.page = max(1, min(page, self.total_pages))
-        self._sync_button_state()
+        if self.session_id is not None:
+            self._build()
+
+    @classmethod
+    async def from_session(
+        cls,
+        interaction: discord.Interaction,
+        session_id: str,
+    ) -> Optional["TodoListDirectoryView"]:
+        session = await asyncio.to_thread(
+            todo_list_directory_sessions.get_session,
+            session_id,
+        )
+        if session is None:
+            return None
+
+        view = cls(
+            server_lists=[],
+            personal_lists=[],
+            current_scope=str(session.get("current_scope") or "server"),
+            guild_id=session.get("guild_id"),
+            channel_id=session.get("channel_id"),
+            channel_name=session.get("channel_name"),
+            user_id=session.get("user_id"),
+            page=max(1, int(session.get("page") or 1)),
+            page_size=max(1, int(session.get("page_size") or 5)),
+            sort_direction=str(session.get("sort_direction") or "ascending"),
+            session_id=str(session.get("session_id") or session_id).strip(),
+        )
+        view.message = interaction.message
+        await view.refresh_entries()
+        await view.ensure_session()
+        return view
+
+    def session_state(self) -> dict:
+        return {
+            "current_scope": self.current_scope,
+            "guild_id": self.guild_id,
+            "channel_id": self.channel_id,
+            "channel_name": self.channel_name,
+            "user_id": self.user_id,
+            "page": self.page,
+            "page_size": self.page_size,
+            "sort_direction": self.sort_direction,
+        }
+
+    async def ensure_session(self) -> str:
+        if self.session_id is None:
+            self.session_id = await asyncio.to_thread(
+                todo_list_directory_sessions.create_session,
+                self.session_state(),
+            )
+        else:
+            await self.save_session()
+        self._build()
+        return self.session_id
+
+    async def save_session(self) -> None:
+        if self.session_id is None:
+            return
+        await asyncio.to_thread(
+            todo_list_directory_sessions.save_session,
+            self.session_id,
+            self.session_state(),
+        )
 
     @staticmethod
     def _normalize_entry(scope: str, entry: Dict[str, Any]) -> Dict[str, Any]:
@@ -188,28 +255,6 @@ class TodoListDirectoryView(discord.ui.View):
             total_items=self.total_items,
             sort_direction=self.sort_direction,
         )
-
-    def _sync_button_state(self) -> None:
-        self.previous_page.disabled = self.page <= 1
-        self.next_page.disabled = self.page >= self.total_pages
-        self.sort_lists.label = None
-        self.sort_lists.emoji = (
-            "🔽" if self.sort_direction == "descending" else "🔼"
-        )
-        self.sort_lists.style = (
-            discord.ButtonStyle.primary
-            if self.sort_direction == "descending"
-            else discord.ButtonStyle.secondary
-        )
-        entry_buttons = [
-            self.open_entry_1,
-            self.open_entry_2,
-            self.open_entry_3,
-            self.open_entry_4,
-            self.open_entry_5,
-        ]
-        for slot_index, button in enumerate(entry_buttons):
-            button.disabled = self._page_entry(slot_index) is None
 
     async def refresh_entries(self) -> None:
         server_lists: List[Dict[str, Any]] = []
@@ -311,7 +356,6 @@ class TodoListDirectoryView(discord.ui.View):
         self._sort_entries()
         self.total_pages = max(1, math.ceil(len(self.entries) / self.page_size))
         self.page = max(1, min(self.page, self.total_pages))
-        self._sync_button_state()
 
     def focus_list(self, list_id: Any) -> None:
         target_id = str(list_id or "").strip()
@@ -322,10 +366,11 @@ class TodoListDirectoryView(discord.ui.View):
             if str(entry.get("_id") or "").strip() != target_id:
                 continue
             self.page = (index // self.page_size) + 1
-            self._sync_button_state()
             return
 
     async def refresh_message(self, interaction: discord.Interaction) -> None:
+        self._build()
+        await self.save_session()
         try:
             if self.message is not None:
                 await self.message.edit(view=self, **self.payload())
@@ -341,7 +386,6 @@ class TodoListDirectoryView(discord.ui.View):
                     cause=exc,
                 ),
             )
-            return
 
     async def _send_list_card(
         self,
@@ -367,7 +411,7 @@ class TodoListDirectoryView(discord.ui.View):
             **result_view.response_payload(),
         )
 
-    async def _open_page_entry(
+    async def open_page_entry(
         self,
         interaction: discord.Interaction,
         slot_index: int,
@@ -416,100 +460,44 @@ class TodoListDirectoryView(discord.ui.View):
         )
         return False
 
-    @discord.ui.button(label="1", style=discord.ButtonStyle.secondary, row=0)
-    async def open_entry_1(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._open_page_entry(interaction, 0)
-
-    @discord.ui.button(label="2", style=discord.ButtonStyle.secondary, row=0)
-    async def open_entry_2(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._open_page_entry(interaction, 1)
-
-    @discord.ui.button(label="3", style=discord.ButtonStyle.secondary, row=0)
-    async def open_entry_3(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._open_page_entry(interaction, 2)
-
-    @discord.ui.button(label="4", style=discord.ButtonStyle.secondary, row=0)
-    async def open_entry_4(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._open_page_entry(interaction, 3)
-
-    @discord.ui.button(label="5", style=discord.ButtonStyle.secondary, row=0)
-    async def open_entry_5(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await self._open_page_entry(interaction, 4)
-
-    @discord.ui.button(style=discord.ButtonStyle.secondary, emoji="◀️", row=1)
-    async def previous_page(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if self.page <= 1:
-            await interaction.response.defer()
+    def _build(self) -> None:
+        self.clear_items()
+        if self.session_id is None:
             return
 
-        self.page -= 1
-        self._sync_button_state()
-        await interaction.response.edit_message(view=self, **self.payload())
-
-    @discord.ui.button(style=discord.ButtonStyle.secondary, emoji="▶️", row=1)
-    async def next_page(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if self.page >= self.total_pages:
-            await interaction.response.defer()
-            return
-
-        self.page += 1
-        self._sync_button_state()
-        await interaction.response.edit_message(view=self, **self.payload())
-
-    @discord.ui.button(style=discord.ButtonStyle.secondary, emoji="🔼", row=1)
-    async def sort_lists(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        self.sort_direction = (
-            "descending"
-            if self.sort_direction == "ascending"
-            else "ascending"
+        from views.todo_list_directory_dynamic_items import (
+            TodoDirectoryCreateButton,
+            TodoDirectoryNextButton,
+            TodoDirectoryOpenButton,
+            TodoDirectoryPrevButton,
+            TodoDirectorySortButton,
         )
-        self._sort_entries()
-        self.page = 1
-        self._sync_button_state()
-        await interaction.response.edit_message(view=self, **self.payload())
 
-    @discord.ui.button(
-        style=discord.ButtonStyle.success,
-        emoji="➕",
-        row=1,
-    )
-    async def create_list(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        self.message = interaction.message
-        await interaction.response.send_modal(TodoListDirectoryCreateModal(self))
+        for slot_index in range(self.page_size):
+            self.add_item(
+                TodoDirectoryOpenButton(
+                    self.session_id,
+                    slot_index,
+                    disabled=self._page_entry(slot_index) is None,
+                )
+            )
+
+        self.add_item(
+            TodoDirectoryPrevButton(
+                self.session_id,
+                disabled=self.page <= 1,
+            )
+        )
+        self.add_item(
+            TodoDirectoryNextButton(
+                self.session_id,
+                disabled=self.page >= self.total_pages,
+            )
+        )
+        self.add_item(
+            TodoDirectorySortButton(
+                self.session_id,
+                descending=self.sort_direction == "descending",
+            )
+        )
+        self.add_item(TodoDirectoryCreateButton(self.session_id))

--- a/views/TogglTimerView.py
+++ b/views/TogglTimerView.py
@@ -17,7 +17,7 @@ class TogglTimerView(discord.ui.View):
         user_id: int,
         timer_data: dict[str, Any],
         is_active: bool,
-        timeout: float = 3600,
+        timeout: float | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.guild_id = guild_id
@@ -26,7 +26,75 @@ class TogglTimerView(discord.ui.View):
         self.is_active = bool(is_active)
         self.is_terminal = False
         self.is_deleted = False
-        self._sync_button_state()
+        self._refresh_state_from_timer_data()
+
+    @staticmethod
+    def _coerce_int(value: object) -> Optional[int]:
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_active_timer(timer_data: dict[str, Any]) -> bool:
+        stop_value = timer_data.get("stop")
+        duration_value = TogglTimerView._coerce_int(timer_data.get("duration"))
+        return stop_value in (None, "") and duration_value is not None and duration_value < 0
+
+    @staticmethod
+    def _create_toggl(user_id: int) -> Optional[TogglFunctions]:
+        api_key = UserSettingsFunctions.get_toggl_api_key(user_id)
+        if not api_key:
+            return None
+        workspace_id = UserSettingsFunctions.get_toggl_workspace_id(user_id)
+        return TogglFunctions(api_key, workspace_id=workspace_id)
+
+    @classmethod
+    async def from_dynamic_reference(
+        cls,
+        *,
+        guild_id: Optional[int],
+        user_id: int,
+        workspace_id: Optional[int],
+        time_entry_id: Optional[int],
+        is_active_hint: bool,
+    ) -> Optional["TogglTimerView"]:
+        toggl = cls._create_toggl(user_id)
+        if toggl is None:
+            return None
+
+        current_timer: Optional[dict[str, Any]] = None
+        if is_active_hint or time_entry_id is None:
+            current_timer = await asyncio.to_thread(toggl.getCurrentTimeEntry)
+            if isinstance(current_timer, dict):
+                current_timer_id = cls._coerce_int(current_timer.get("id"))
+                if current_timer_id is not None and (
+                    time_entry_id is None or current_timer_id == time_entry_id
+                ):
+                    return cls(
+                        guild_id=guild_id,
+                        user_id=user_id,
+                        timer_data=current_timer,
+                        is_active=cls._is_active_timer(current_timer),
+                    )
+
+        if workspace_id is None or time_entry_id is None:
+            return None
+
+        timer_data = await asyncio.to_thread(
+            toggl.getTimeEntry,
+            workspace_id,
+            time_entry_id,
+        )
+        if not isinstance(timer_data, dict) or timer_data.get("id") is None:
+            return None
+
+        return cls(
+            guild_id=guild_id,
+            user_id=user_id,
+            timer_data=timer_data,
+            is_active=cls._is_active_timer(timer_data),
+        )
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id == self.user_id:
@@ -38,20 +106,67 @@ class TogglTimerView(discord.ui.View):
         return False
 
     def _sync_button_state(self) -> None:
-        self.play_pause_button.disabled = self.is_terminal or self.is_deleted
-        self.stop_button.disabled = self.is_terminal or self.is_deleted or not self.is_active
-        self.edit_button.disabled = self.is_deleted
-        self.delete_button.disabled = self.is_deleted
-        self.list_timers_button.disabled = False
+        self._build()
 
-        self.play_pause_button.label = None
-        if self.is_active:
-            self.play_pause_button.emoji = "⏸️"
-            self.play_pause_button.style = discord.ButtonStyle.secondary
-            return
+    def _build(self) -> None:
+        self.clear_items()
 
-        self.play_pause_button.emoji = "▶️"
-        self.play_pause_button.style = discord.ButtonStyle.success
+        from views.toggl_dynamic_items import (
+            TogglDeleteButton,
+            TogglEditButton,
+            TogglListTimersButton,
+            TogglPlayPauseButton,
+            TogglStopButton,
+        )
+
+        guild_id = int(self.guild_id or 0)
+        workspace_id = int(self._workspace_id() or 0)
+        time_entry_id = int(self._time_entry_id() or 0)
+
+        self.add_item(
+            TogglPlayPauseButton(
+                guild_id=guild_id,
+                user_id=self.user_id,
+                workspace_id=workspace_id,
+                time_entry_id=time_entry_id,
+                is_active=self.is_active,
+                disabled=self.is_terminal or self.is_deleted,
+            )
+        )
+        self.add_item(
+            TogglStopButton(
+                guild_id=guild_id,
+                user_id=self.user_id,
+                workspace_id=workspace_id,
+                time_entry_id=time_entry_id,
+                is_active=self.is_active,
+                disabled=self.is_terminal or self.is_deleted or not self.is_active,
+            )
+        )
+        self.add_item(
+            TogglEditButton(
+                guild_id=guild_id,
+                user_id=self.user_id,
+                workspace_id=workspace_id,
+                time_entry_id=time_entry_id,
+                disabled=self.is_deleted,
+            )
+        )
+        self.add_item(
+            TogglDeleteButton(
+                guild_id=guild_id,
+                user_id=self.user_id,
+                workspace_id=workspace_id,
+                time_entry_id=time_entry_id,
+                disabled=self.is_deleted,
+            )
+        )
+        self.add_item(
+            TogglListTimersButton(
+                guild_id=guild_id,
+                user_id=self.user_id,
+            )
+        )
 
     @staticmethod
     def _extract_start_params(timer_data: dict[str, Any]) -> dict[str, Any]:
@@ -65,34 +180,19 @@ class TogglTimerView(discord.ui.View):
         }
 
     def _get_toggl(self) -> Optional[TogglFunctions]:
-        api_key = UserSettingsFunctions.get_toggl_api_key(self.user_id)
-        if not api_key:
-            return None
-        workspace_id = UserSettingsFunctions.get_toggl_workspace_id(self.user_id)
-        return TogglFunctions(api_key, workspace_id=workspace_id)
+        return self._create_toggl(self.user_id)
 
     def _time_entry_id(self) -> Optional[int]:
-        value = self.timer_data.get("id")
-        try:
-            return int(value) if value is not None else None
-        except (TypeError, ValueError):
-            return None
+        return self._coerce_int(self.timer_data.get("id"))
 
     def _workspace_id(self) -> Optional[int]:
-        value = self.timer_data.get("workspace_id") or self.timer_data.get("wid")
-        try:
-            return int(value) if value is not None else None
-        except (TypeError, ValueError):
-            return None
+        return self._coerce_int(
+            self.timer_data.get("workspace_id") or self.timer_data.get("wid")
+        )
 
     def _refresh_state_from_timer_data(self) -> None:
-        stop_value = self.timer_data.get("stop")
-        duration_value = self.timer_data.get("duration")
-        try:
-            parsed_duration = int(duration_value)
-        except (TypeError, ValueError):
-            parsed_duration = None
-        self.is_active = stop_value in (None, "") and parsed_duration is not None and parsed_duration < 0
+        if self.timer_data:
+            self.is_active = self._is_active_timer(self.timer_data)
         self._sync_button_state()
 
     async def _send_error(
@@ -155,6 +255,7 @@ class TogglTimerView(discord.ui.View):
             color=color,
         )
         updated_embed = self._preserve_extra_fields(current_embed, updated_embed)
+        self._build()
         await interaction.response.edit_message(embed=updated_embed, view=self)
 
     async def _refresh_message(
@@ -183,6 +284,7 @@ class TogglTimerView(discord.ui.View):
             color=color,
         )
         updated_embed = self._preserve_extra_fields(current_embed, updated_embed)
+        self._build()
         try:
             await source_message.edit(embed=updated_embed, view=self)
         except (discord.NotFound, discord.Forbidden, discord.HTTPException):
@@ -197,6 +299,8 @@ class TogglTimerView(discord.ui.View):
         source_message: Optional[discord.Message],
     ) -> None:
         self.timer_data = dict(updated_timer or {})
+        self.is_terminal = False
+        self.is_deleted = False
         self._refresh_state_from_timer_data()
         refreshed = await self._refresh_message(
             source_message,
@@ -210,12 +314,7 @@ class TogglTimerView(discord.ui.View):
                 content="Timer updated.",
             )
 
-    @discord.ui.button(emoji="⏸️", style=discord.ButtonStyle.secondary, row=0)
-    async def play_pause_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
+    async def _handle_play_pause(self, interaction: discord.Interaction) -> None:
         try:
             toggl = self._get_toggl()
         except Exception:
@@ -231,24 +330,35 @@ class TogglTimerView(discord.ui.View):
         try:
             if self.is_active:
                 current_timer = await asyncio.to_thread(toggl.getCurrentTimeEntry)
-                if current_timer is not None:
-                    stopped_timer = await asyncio.to_thread(toggl.stopCurrentTimeEntry)
-                    if (
-                        not isinstance(stopped_timer, dict)
-                        or stopped_timer.get("id") is None
-                    ):
-                        await self._send_error(
-                            interaction,
-                            "Toggl rejected that timer stop request.",
-                        )
-                        return
-                    self.timer_data = stopped_timer
-                self.is_active = False
-                self._sync_button_state()
+                current_timer_id = self._coerce_int(
+                    current_timer.get("id") if isinstance(current_timer, dict) else None
+                )
+                if current_timer_id != self._time_entry_id():
+                    await self._send_error(
+                        interaction,
+                        "That timer is no longer running. Reopen it and try again.",
+                    )
+                    return
+
+                stopped_timer = await asyncio.to_thread(toggl.stopCurrentTimeEntry)
+                if (
+                    not isinstance(stopped_timer, dict)
+                    or stopped_timer.get("id") is None
+                ):
+                    await self._send_error(
+                        interaction,
+                        "Toggl rejected that timer stop request.",
+                    )
+                    return
+
+                self.timer_data = stopped_timer
+                self.is_terminal = False
+                self.is_deleted = False
+                self._refresh_state_from_timer_data()
                 await self._render_message(
                     interaction,
                     title=":stopwatch: Toggl Timer Paused",
-                    description="Timer paused. Use ▶️ to start a new timer with the same details.",
+                    description="Timer paused. Use \u25b6\ufe0f to start a new timer with the same details.",
                     color="#c96a40",
                 )
                 return
@@ -281,10 +391,9 @@ class TogglTimerView(discord.ui.View):
                 return
 
             self.timer_data = started_timer
-            self.is_active = True
             self.is_terminal = False
             self.is_deleted = False
-            self._sync_button_state()
+            self._refresh_state_from_timer_data()
             await self._render_message(
                 interaction,
                 title=":stopwatch: Toggl Timer Started",
@@ -296,12 +405,7 @@ class TogglTimerView(discord.ui.View):
                 "I couldn't update that Toggl timer right now. Please try again.",
             )
 
-    @discord.ui.button(emoji="⏹️", style=discord.ButtonStyle.danger, row=0)
-    async def stop_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
+    async def _handle_stop(self, interaction: discord.Interaction) -> None:
         try:
             toggl = self._get_toggl()
         except Exception:
@@ -316,22 +420,28 @@ class TogglTimerView(discord.ui.View):
 
         try:
             current_timer = await asyncio.to_thread(toggl.getCurrentTimeEntry)
-            if current_timer is not None:
-                stopped_timer = await asyncio.to_thread(toggl.stopCurrentTimeEntry)
-                if (
-                    not isinstance(stopped_timer, dict)
-                    or stopped_timer.get("id") is None
-                ):
-                    await self._send_error(
-                        interaction,
-                        "Toggl rejected that timer stop request.",
-                    )
-                    return
-                self.timer_data = stopped_timer
+            current_timer_id = self._coerce_int(
+                current_timer.get("id") if isinstance(current_timer, dict) else None
+            )
+            if current_timer_id != self._time_entry_id():
+                await self._send_error(
+                    interaction,
+                    "That timer is no longer running. Reopen it and try again.",
+                )
+                return
 
-            self.is_active = False
+            stopped_timer = await asyncio.to_thread(toggl.stopCurrentTimeEntry)
+            if not isinstance(stopped_timer, dict) or stopped_timer.get("id") is None:
+                await self._send_error(
+                    interaction,
+                    "Toggl rejected that timer stop request.",
+                )
+                return
+
+            self.timer_data = stopped_timer
             self.is_terminal = True
-            self._sync_button_state()
+            self.is_deleted = False
+            self._refresh_state_from_timer_data()
             await self._render_message(
                 interaction,
                 title=":stopwatch: Toggl Timer Stopped",
@@ -344,12 +454,7 @@ class TogglTimerView(discord.ui.View):
                 "I couldn't stop that Toggl timer right now. Please try again.",
             )
 
-    @discord.ui.button(emoji="✏️", style=discord.ButtonStyle.primary, row=0)
-    async def edit_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
+    async def _handle_edit(self, interaction: discord.Interaction) -> None:
         try:
             toggl = self._get_toggl()
         except Exception:
@@ -404,12 +509,7 @@ class TogglTimerView(discord.ui.View):
             )
         )
 
-    @discord.ui.button(emoji="🗑️", style=discord.ButtonStyle.danger, row=0)
-    async def delete_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
+    async def _handle_delete(self, interaction: discord.Interaction) -> None:
         try:
             toggl = self._get_toggl()
         except Exception:
@@ -462,12 +562,7 @@ class TogglTimerView(discord.ui.View):
                 "I couldn't delete that Toggl timer right now. Please try again.",
             )
 
-    @discord.ui.button(emoji="📋", style=discord.ButtonStyle.secondary, row=0)
-    async def list_timers_button(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
+    async def _handle_list_timers(self, interaction: discord.Interaction) -> None:
         from embeds.TogglEmbeds import TogglEmbeds
         from views.TogglTimerHistoryView import TogglTimerHistoryView
 

--- a/views/crypto_action_dynamic_items.py
+++ b/views/crypto_action_dynamic_items.py
@@ -1,0 +1,99 @@
+import discord
+from discord.ext import commands
+
+
+async def register_crypto_action_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        CryptoSetAlertButton,
+        CryptoScheduleDailyCheckButton,
+    )
+
+
+def _build_view(coin_id: str, currency: str):
+    from views.CryptoActionView import CryptoActionView
+
+    return CryptoActionView(coin_id, currency)
+
+
+class CryptoSetAlertButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"cryptoaction:alert:(?P<coin_id>[^:]+):(?P<currency>[^:]+)",
+):
+    def __init__(
+        self,
+        *,
+        coin_id: str,
+        currency: str,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Set Alert",
+                style=discord.ButtonStyle.success,
+                custom_id=f"cryptoaction:alert:{coin_id}:{currency}",
+                disabled=disabled,
+            )
+        )
+        self.coin_id = coin_id
+        self.currency = currency
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "CryptoSetAlertButton":
+        del interaction
+        return cls(
+            coin_id=match.group("coin_id"),
+            currency=match.group("currency"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = _build_view(self.coin_id, self.currency)
+        await view.open_set_alert_modal(interaction)
+
+
+class CryptoScheduleDailyCheckButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"cryptoaction:schedule:(?P<coin_id>[^:]+):(?P<currency>[^:]+)",
+):
+    def __init__(
+        self,
+        *,
+        coin_id: str,
+        currency: str,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Schedule Daily Check",
+                style=discord.ButtonStyle.secondary,
+                custom_id=f"cryptoaction:schedule:{coin_id}:{currency}",
+                disabled=disabled,
+            )
+        )
+        self.coin_id = coin_id
+        self.currency = currency
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "CryptoScheduleDailyCheckButton":
+        del interaction
+        return cls(
+            coin_id=match.group("coin_id"),
+            currency=match.group("currency"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = _build_view(self.coin_id, self.currency)
+        await view.open_schedule_daily_check_modal(interaction)

--- a/views/habit_dynamic_items.py
+++ b/views/habit_dynamic_items.py
@@ -1,0 +1,226 @@
+import asyncio
+
+import discord
+from discord.ext import commands
+
+from classes.HabitFunctions import HabitFunctions
+
+
+async def register_habit_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        HabitCompleteButton,
+        HabitSkipButton,
+        HabitIncompleteButton,
+    )
+
+
+async def _ensure_allowed(
+    interaction: discord.Interaction,
+    *,
+    user_id: int,
+) -> bool:
+    if interaction.user.id == user_id:
+        return True
+
+    await interaction.response.send_message(
+        ephemeral=True,
+        content="Only the habit owner can update this habit.",
+    )
+    return False
+
+
+async def _refresh_habit_message(
+    interaction: discord.Interaction,
+    *,
+    habit_id: str,
+    user_id: int,
+) -> None:
+    from views.HabitActionView import HabitActionView
+
+    view = HabitActionView(habit_id, "Habit", user_id)
+    await view.refresh_message(interaction)
+
+
+async def _record_completion(
+    interaction: discord.Interaction,
+    *,
+    habit_id: str,
+    user_id: int,
+    mode: str,
+) -> None:
+    await interaction.response.defer(ephemeral=True)
+    updated = await asyncio.to_thread(
+        HabitFunctions.add_completion,
+        habit_id,
+        interaction.guild_id,
+        mode,
+    )
+    if not updated:
+        await interaction.followup.send(
+            ephemeral=True,
+            content="Couldn't update that habit.",
+        )
+        return
+
+    await _refresh_habit_message(
+        interaction,
+        habit_id=habit_id,
+        user_id=user_id,
+    )
+    habit = await asyncio.to_thread(
+        HabitFunctions.fetch_habit,
+        habit_id,
+        interaction.guild_id,
+    )
+    habit_name = str((habit or {}).get("name") or "Habit")
+    await interaction.followup.send(
+        ephemeral=True,
+        content=f"Marked '{habit_name}' as {mode}.",
+    )
+
+
+class HabitCompleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"habit:complete:(?P<habit_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        habit_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="complete",
+                style=discord.ButtonStyle.success,
+                custom_id=f"habit:complete:{habit_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.habit_id = habit_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "HabitCompleteButton":
+        del interaction
+        return cls(
+            match.group("habit_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await _ensure_allowed(interaction, user_id=self.user_id):
+            return
+
+        await _record_completion(
+            interaction,
+            habit_id=self.habit_id,
+            user_id=self.user_id,
+            mode="complete",
+        )
+
+
+class HabitSkipButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"habit:skip:(?P<habit_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        habit_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="skip",
+                style=discord.ButtonStyle.secondary,
+                custom_id=f"habit:skip:{habit_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.habit_id = habit_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "HabitSkipButton":
+        del interaction
+        return cls(
+            match.group("habit_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await _ensure_allowed(interaction, user_id=self.user_id):
+            return
+
+        await _record_completion(
+            interaction,
+            habit_id=self.habit_id,
+            user_id=self.user_id,
+            mode="skip",
+        )
+
+
+class HabitIncompleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"habit:incomplete:(?P<habit_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        habit_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="incomplete",
+                style=discord.ButtonStyle.danger,
+                custom_id=f"habit:incomplete:{habit_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.habit_id = habit_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "HabitIncompleteButton":
+        del interaction
+        return cls(
+            match.group("habit_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await _ensure_allowed(interaction, user_id=self.user_id):
+            return
+
+        await _record_completion(
+            interaction,
+            habit_id=self.habit_id,
+            user_id=self.user_id,
+            mode="incomplete",
+        )

--- a/views/pomodoro_dynamic_items.py
+++ b/views/pomodoro_dynamic_items.py
@@ -1,0 +1,827 @@
+import asyncio
+import datetime
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+from classes.PomodoroFunctions import PomodoroFunctions
+from classes.PomodoroVoiceManager import PomodoroVoiceManager
+from embeds.PomodoroEmbeds import PomodoroEmbeds
+from services.error_reporting import (
+    UserVisibleError,
+    ValidationError,
+    handle_interaction_error,
+)
+
+
+async def register_pomodoro_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        PomodoroRestartFocusButton,
+        PomodoroRestartBreakButton,
+        PomodoroStartSelectVoiceButton,
+        PomodoroStartPlayPauseButton,
+        PomodoroStartExtendButton,
+        PomodoroStartStopButton,
+        PomodoroStoppedFocusButton,
+        PomodoroStoppedBreakButton,
+        PomodoroStoppedCustomTimerButton,
+    )
+
+
+def _current_join_url(interaction: discord.Interaction) -> Optional[str]:
+    if interaction.guild is None:
+        return None
+
+    session = PomodoroVoiceManager.sessions.get(interaction.guild.id)
+    if session is None:
+        return None
+
+    channel = interaction.guild.get_channel(session.voice_channel_id)
+    if not isinstance(channel, discord.VoiceChannel):
+        return None
+    return channel.jump_url
+
+
+async def _ensure_owner(interaction: discord.Interaction, user_id: int) -> bool:
+    if interaction.user.id == user_id:
+        return True
+
+    await interaction.response.send_message(
+        ephemeral=False,
+        content="Only the user who started this pomodoro can do this.",
+    )
+    return False
+
+
+async def _ensure_stopped_owner(interaction: discord.Interaction, user_id: int) -> bool:
+    if interaction.user.id == user_id:
+        return True
+
+    await interaction.response.send_message(
+        ephemeral=False,
+        content="Only the user who stopped this pomodoro can do this.",
+    )
+    return False
+
+
+async def _disable_source_message(
+    source_message: Optional[discord.Message],
+    view: discord.ui.View,
+) -> None:
+    if source_message is None:
+        return
+    try:
+        await source_message.edit(view=view)
+    except discord.HTTPException:
+        pass
+
+
+async def _send_started_pomodoro(
+    interaction: discord.Interaction,
+    *,
+    mode: str,
+    duration: Optional[int],
+    target_channel: Optional[discord.VoiceChannel],
+    use_member_voice: bool,
+    skip_voice: bool,
+    source_message: Optional[discord.Message] = None,
+    source_disabled_view: Optional[discord.ui.View] = None,
+) -> None:
+    from views.PomodoroStartView import PomodoroStartView
+
+    try:
+        end_time, resolved_duration = await asyncio.to_thread(
+            PomodoroFunctions.create_timer,
+            interaction.guild_id,
+            interaction.channel_id,
+            mode,
+            duration,
+            interaction.user.id,
+        )
+    except ValueError as exc:
+        await handle_interaction_error(
+            interaction,
+            ValidationError(
+                str(exc),
+                ephemeral=False,
+                cause=exc,
+            ),
+        )
+        return
+    except Exception as exc:
+        await handle_interaction_error(
+            interaction,
+            UserVisibleError(
+                "Something went wrong while starting that pomodoro.",
+                ephemeral=False,
+                cause=exc,
+            ),
+        )
+        return
+
+    voice_error: Optional[str] = None
+    resolved_target_channel = target_channel
+
+    if skip_voice:
+        voice_error = None
+    elif interaction.guild is None:
+        voice_error = None
+    else:
+        member = interaction.user
+        if resolved_target_channel is None and use_member_voice:
+            if isinstance(member, discord.Member) and member.voice:
+                resolved_target_channel = member.voice.channel
+
+        if resolved_target_channel is None:
+            voice_error = "Join a voice channel so I can play audio."
+        else:
+            voice_error = await PomodoroVoiceManager.start_session(
+                interaction.guild,
+                resolved_target_channel,
+                end_time,
+                mode,
+            )
+
+    payload = PomodoroEmbeds.insert_timer_embed(
+        mode,
+        resolved_duration,
+        end_time,
+    )
+    join_url = resolved_target_channel.jump_url if resolved_target_channel else None
+    payload["view"] = PomodoroStartView(
+        interaction.user.id,
+        join_url=join_url if voice_error is None else None,
+        mode=mode,
+        end_time=end_time,
+        voice_channel_select_enabled=interaction.guild is not None,
+    )
+
+    await interaction.followup.send(ephemeral=False, **payload)
+
+    if voice_error:
+        await interaction.followup.send(ephemeral=False, content=voice_error)
+
+    if source_disabled_view is not None:
+        await _disable_source_message(source_message, source_disabled_view)
+
+
+class PomodoroRestartFocusButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:restart:focus",
+):
+    def __init__(self, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Start Focus",
+                style=discord.ButtonStyle.success,
+                custom_id="pomodoro:restart:focus",
+                disabled=disabled,
+            )
+        )
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroRestartFocusButton":
+        del interaction, match
+        return cls(disabled=getattr(item, "disabled", False))
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroRestartView import PomodoroRestartView
+
+        await interaction.response.defer(ephemeral=False)
+        await _send_started_pomodoro(
+            interaction,
+            mode="focus",
+            duration=None,
+            target_channel=None,
+            use_member_voice=True,
+            skip_voice=False,
+            source_message=interaction.message,
+            source_disabled_view=PomodoroRestartView(disabled=True),
+        )
+
+
+class PomodoroRestartBreakButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:restart:break",
+):
+    def __init__(self, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Start Relax",
+                style=discord.ButtonStyle.secondary,
+                custom_id="pomodoro:restart:break",
+                disabled=disabled,
+            )
+        )
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroRestartBreakButton":
+        del interaction, match
+        return cls(disabled=getattr(item, "disabled", False))
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroRestartView import PomodoroRestartView
+
+        await interaction.response.defer(ephemeral=False)
+        await _send_started_pomodoro(
+            interaction,
+            mode="break",
+            duration=None,
+            target_channel=None,
+            use_member_voice=True,
+            skip_voice=False,
+            source_message=interaction.message,
+            source_disabled_view=PomodoroRestartView(disabled=True),
+        )
+
+
+class PomodoroStartSelectVoiceButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:start:voice:(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        user_id: int,
+        *,
+        disabled: bool = False,
+        server_only: bool = False,
+    ) -> None:
+        label = "Select Voice Channel (Server only)" if server_only else "Select Voice Channel"
+        style = (
+            discord.ButtonStyle.secondary if server_only else discord.ButtonStyle.primary
+        )
+        super().__init__(
+            discord.ui.Button(
+                label=label,
+                style=style,
+                custom_id=f"pomodoro:start:voice:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroStartSelectVoiceButton":
+        del interaction
+        label = getattr(item, "label", "") or ""
+        server_only = "server only" in label.lower()
+        return cls(
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+            server_only=server_only,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroStartView import (
+            PomodoroVoiceChannelSelectModal,
+            PomodoroVoiceChannelSelectView,
+        )
+
+        if not await _ensure_owner(interaction, self.user_id):
+            return
+
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content="Voice channel selection isn't available in DMs.",
+            )
+            return
+
+        state = await PomodoroFunctions.get_user_pomodoro_state(interaction)
+        if not state.exists:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content=(
+                    "You don't have an active pomodoro "
+                    f"{PomodoroFunctions._scope_message(interaction)}."
+                ),
+            )
+            return
+
+        voice_channel_options = PomodoroVoiceChannelSelectView._build_voice_channel_options(
+            interaction
+        )
+        if not voice_channel_options:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content="No available voice channels found.",
+            )
+            return
+
+        import views.PomodoroStartView as start_view_module
+
+        if start_view_module._POMODORO_MODAL_SELECTS_SUPPORTED:
+            try:
+                await interaction.response.send_modal(
+                    PomodoroVoiceChannelSelectModal(
+                        user_id=self.user_id,
+                        mode=state.mode,
+                        end_time=state.end_time,
+                        voice_channel_options=voice_channel_options,
+                    )
+                )
+                return
+            except discord.HTTPException as exc:
+                if exc.code == 50035 and "must be one of (4,)" in str(exc):
+                    start_view_module._POMODORO_MODAL_SELECTS_SUPPORTED = False
+                else:
+                    raise
+
+        picker_view = PomodoroVoiceChannelSelectView(
+            interaction=interaction,
+            user_id=self.user_id,
+            mode=state.mode,
+            end_time=state.end_time,
+        )
+        await interaction.response.send_message(
+            ephemeral=False,
+            content="Choose a voice channel:",
+            view=picker_view,
+        )
+
+
+class PomodoroStartPlayPauseButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:start:toggle:(?P<user_id>\d+)",
+):
+    def __init__(self, user_id: int, *, paused: bool = False, disabled: bool = False) -> None:
+        label = "Resume" if paused else "Pause"
+        emoji = "▶️" if paused else "⏸️"
+        style = (
+            discord.ButtonStyle.success if paused else discord.ButtonStyle.secondary
+        )
+        super().__init__(
+            discord.ui.Button(
+                label=label,
+                style=style,
+                emoji=emoji,
+                custom_id=f"pomodoro:start:toggle:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroStartPlayPauseButton":
+        del interaction
+        label = getattr(item, "label", "") or ""
+        paused = label.lower() == "resume"
+        return cls(
+            int(match.group("user_id")),
+            paused=paused,
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroStartView import PomodoroStartView
+
+        if not await _ensure_owner(interaction, self.user_id):
+            return
+
+        state = await PomodoroFunctions.get_user_pomodoro_state(interaction)
+        if not state.exists:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content=(
+                    "You don't have an active pomodoro "
+                    f"{PomodoroFunctions._scope_message(interaction)}."
+                ),
+            )
+            return
+
+        if state.is_paused:
+            result = await PomodoroFunctions.resume_user_pomodoro(interaction)
+            if not result.ok or result.end_time is None or result.duration_minutes is None:
+                await interaction.response.send_message(
+                    ephemeral=False,
+                    content=result.message,
+                )
+                return
+
+            mode = result.mode or state.mode
+            updated_embed = PomodoroStartView._with_resumed_timer_fields(
+                (
+                    interaction.message.embeds[0]
+                    if interaction.message and interaction.message.embeds
+                    else None
+                ),
+                mode,
+                result.end_time,
+                result.duration_minutes,
+            )
+            if updated_embed is None:
+                await interaction.response.send_message(
+                    ephemeral=False,
+                    content=(
+                        "Pomodoro resumed, but I couldn't refresh the timer card. "
+                        f"New end: {PomodoroStartView._relative_timestamp(result.end_time)}"
+                    ),
+                )
+                return
+
+            await interaction.response.edit_message(
+                embed=updated_embed,
+                view=PomodoroStartView(
+                    self.user_id,
+                    join_url=_current_join_url(interaction),
+                    mode=mode,
+                    end_time=result.end_time,
+                    is_paused=False,
+                    voice_channel_select_enabled=interaction.guild is not None,
+                ),
+            )
+            return
+
+        result = await PomodoroFunctions.pause_user_pomodoro(interaction)
+        if not result.ok:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content=result.message,
+            )
+            return
+
+        remaining_minutes = result.remaining_minutes or 1
+        mode = result.mode or state.mode
+        updated_embed = PomodoroStartView._with_paused_timer_fields(
+            (
+                interaction.message.embeds[0]
+                if interaction.message and interaction.message.embeds
+                else None
+            ),
+            mode,
+            remaining_minutes,
+        )
+        if updated_embed is None:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content=f"Paused with {remaining_minutes} minute(s) remaining.",
+            )
+            return
+
+        await interaction.response.edit_message(
+            embed=updated_embed,
+            view=PomodoroStartView(
+                self.user_id,
+                join_url=_current_join_url(interaction),
+                mode=mode,
+                end_time=None,
+                is_paused=True,
+                voice_channel_select_enabled=interaction.guild is not None,
+            ),
+        )
+
+
+class PomodoroStartExtendButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:start:extend:(?P<user_id>\d+)",
+):
+    def __init__(self, user_id: int, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Extend +5 min",
+                style=discord.ButtonStyle.secondary,
+                custom_id=f"pomodoro:start:extend:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroStartExtendButton":
+        del interaction
+        return cls(
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroStartView import PomodoroStartView
+
+        if not await _ensure_owner(interaction, self.user_id):
+            return
+
+        state = await PomodoroFunctions.get_user_pomodoro_state(interaction)
+        if not state.exists:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content=(
+                    "You don't have an active pomodoro "
+                    f"{PomodoroFunctions._scope_message(interaction)}."
+                ),
+            )
+            return
+
+        if state.is_paused:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content="Resume the pomodoro before extending it.",
+            )
+            return
+
+        result = await PomodoroFunctions.extend_user_pomodoro(
+            interaction,
+            minutes=5,
+            expected_end_time=state.end_time,
+        )
+        if not result.ok or result.end_time is None or result.duration_minutes is None:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content=result.message,
+            )
+            return
+
+        updated_embed = PomodoroStartView._with_updated_timer_fields(
+            (
+                interaction.message.embeds[0]
+                if interaction.message and interaction.message.embeds
+                else None
+            ),
+            result.end_time,
+            result.duration_minutes,
+        )
+        if updated_embed is None:
+            await interaction.response.send_message(
+                ephemeral=False,
+                content=(
+                    "Extended by 5 minutes, but I couldn't refresh the timer card. "
+                    f"New end: {PomodoroStartView._relative_timestamp(result.end_time)}"
+                ),
+            )
+            return
+
+        try:
+            await interaction.response.edit_message(
+                embed=updated_embed,
+                view=PomodoroStartView(
+                    self.user_id,
+                    join_url=_current_join_url(interaction),
+                    mode=result.mode or state.mode,
+                    end_time=result.end_time,
+                    is_paused=False,
+                    voice_channel_select_enabled=interaction.guild is not None,
+                ),
+            )
+        except discord.HTTPException:
+            fallback_message = (
+                "Extended by 5 minutes, but that timer message no longer exists. "
+                f"New end: {PomodoroStartView._relative_timestamp(result.end_time)}"
+            )
+            if interaction.response.is_done():
+                await interaction.followup.send(
+                    ephemeral=False,
+                    content=fallback_message,
+                )
+            else:
+                await interaction.response.send_message(
+                    ephemeral=False,
+                    content=fallback_message,
+                )
+
+
+class PomodoroStartStopButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:start:stop:(?P<user_id>\d+)",
+):
+    def __init__(self, user_id: int, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Stop Pomodoro",
+                style=discord.ButtonStyle.danger,
+                custom_id=f"pomodoro:start:stop:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroStartStopButton":
+        del interaction
+        return cls(
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroStoppedView import PomodoroStoppedView
+
+        if not await _ensure_owner(interaction, self.user_id):
+            return
+
+        await interaction.response.defer(ephemeral=False)
+        result = await PomodoroFunctions.stop_user_pomodoro(interaction)
+        if not result.ok:
+            await interaction.followup.send(ephemeral=False, content=result.message)
+            return
+
+        payload = PomodoroEmbeds.timer_stopped_embed(result.message)
+        replacement_view = PomodoroStoppedView(interaction.user.id)
+        if interaction.message is not None:
+            try:
+                await interaction.message.edit(**payload, view=replacement_view)
+                return
+            except discord.HTTPException:
+                pass
+
+        await interaction.followup.send(
+            ephemeral=False,
+            **payload,
+            view=replacement_view,
+        )
+
+
+class PomodoroStoppedFocusButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:stopped:focus:(?P<user_id>\d+)",
+):
+    def __init__(self, user_id: int, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Start Focus",
+                style=discord.ButtonStyle.success,
+                custom_id=f"pomodoro:stopped:focus:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroStoppedFocusButton":
+        del interaction
+        return cls(
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroStoppedView import PomodoroStoppedView
+
+        if not await _ensure_stopped_owner(interaction, self.user_id):
+            return
+
+        await interaction.response.defer(ephemeral=False)
+        await _send_started_pomodoro(
+            interaction,
+            mode="focus",
+            duration=None,
+            target_channel=None,
+            use_member_voice=True,
+            skip_voice=False,
+            source_message=interaction.message,
+            source_disabled_view=PomodoroStoppedView(self.user_id, disabled=True),
+        )
+
+
+class PomodoroStoppedBreakButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:stopped:break:(?P<user_id>\d+)",
+):
+    def __init__(self, user_id: int, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Start Break",
+                style=discord.ButtonStyle.primary,
+                custom_id=f"pomodoro:stopped:break:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroStoppedBreakButton":
+        del interaction
+        return cls(
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroStoppedView import PomodoroStoppedView
+
+        if not await _ensure_stopped_owner(interaction, self.user_id):
+            return
+
+        await interaction.response.defer(ephemeral=False)
+        await _send_started_pomodoro(
+            interaction,
+            mode="break",
+            duration=None,
+            target_channel=None,
+            use_member_voice=True,
+            skip_voice=False,
+            source_message=interaction.message,
+            source_disabled_view=PomodoroStoppedView(self.user_id, disabled=True),
+        )
+
+
+class PomodoroStoppedCustomTimerButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"pomodoro:stopped:custom:(?P<user_id>\d+)",
+):
+    def __init__(self, user_id: int, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Custom Timer",
+                style=discord.ButtonStyle.secondary,
+                custom_id=f"pomodoro:stopped:custom:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "PomodoroStoppedCustomTimerButton":
+        del interaction
+        return cls(
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.PomodoroStoppedView import (
+            PomodoroCustomTimerModal,
+            build_custom_voice_options,
+        )
+        import views.PomodoroStoppedView as stopped_view_module
+
+        if not await _ensure_stopped_owner(interaction, self.user_id):
+            return
+
+        voice_options = build_custom_voice_options(interaction)
+        if stopped_view_module._POMODORO_STOP_MODAL_SELECTS_SUPPORTED:
+            try:
+                await interaction.response.send_modal(
+                    PomodoroCustomTimerModal(
+                        user_id=self.user_id,
+                        source_message=interaction.message,
+                        voice_options=voice_options,
+                    )
+                )
+                return
+            except discord.HTTPException as exc:
+                if exc.code == 50035 and "must be one of (4,)" in str(exc):
+                    stopped_view_module._POMODORO_STOP_MODAL_SELECTS_SUPPORTED = False
+                else:
+                    raise
+
+        await interaction.response.send_message(
+            ephemeral=False,
+            content=(
+                "Custom timer popup with dropdowns is not supported here. "
+                "Use `/pomodoro start` for custom mode, duration, and voice options."
+            ),
+        )

--- a/views/reminder_dynamic_items.py
+++ b/views/reminder_dynamic_items.py
@@ -1,0 +1,810 @@
+import asyncio
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+from classes.ReminderFunctions import ReminderFunctions
+from services.error_reporting import ValidationError, handle_interaction_error
+from services.reminder_destination import build_reminder_destination_select_options
+
+
+async def register_reminder_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        ReminderAddButton,
+        ReminderEditButton,
+        ReminderPingButton,
+        ReminderToggleButton,
+        ReminderDeleteButton,
+        ReminderListItemButton,
+        ReminderListPrevButton,
+        ReminderListNextButton,
+        ReminderListAddButton,
+        ReminderListOptionsButton,
+    )
+
+
+def _bool_flag(value: bool) -> str:
+    return "1" if value else "0"
+
+
+def _parse_bool_flag(value: str) -> bool:
+    return str(value or "").strip() == "1"
+
+
+async def _build_output_view(
+    interaction: discord.Interaction,
+    *,
+    job_id: str,
+    user_id: int,
+    response_ephemeral: bool,
+    result_message: Optional[str] = None,
+    ok: Optional[bool] = None,
+):
+    from views.ReminderOutputView import ReminderOutputView
+
+    job = await asyncio.to_thread(
+        ReminderFunctions.get_reminder,
+        job_id,
+        interaction.guild_id,
+    )
+    if result_message is None:
+        result_message = (
+            f"Showing reminder `{job_id}`."
+            if job is not None
+            else "This reminder is no longer available."
+        )
+    if ok is None:
+        ok = job is not None
+
+    view = ReminderOutputView(
+        job=job,
+        guild=interaction.guild,
+        result_message=result_message,
+        ok=ok,
+        user_id=user_id or None,
+        response_ephemeral=response_ephemeral,
+        job_id=job_id,
+        guild_id=interaction.guild_id,
+        channel_id=interaction.channel_id,
+    )
+    view.message = interaction.message
+    return view
+
+
+async def _ensure_allowed(
+    interaction: discord.Interaction,
+    *,
+    user_id: int,
+    response_ephemeral: bool,
+) -> bool:
+    if user_id == 0 or interaction.user.id == user_id:
+        return True
+
+    await interaction.response.send_message(
+        "Only the user who opened this reminder can manage it.",
+        ephemeral=response_ephemeral,
+    )
+    return False
+
+
+async def _build_list_view(
+    interaction: discord.Interaction,
+    *,
+    session_id: str,
+):
+    from views.ReminderListView import ReminderListView
+
+    return await ReminderListView.from_session(interaction, session_id)
+
+
+async def _ensure_list_view(
+    interaction: discord.Interaction,
+    *,
+    session_id: str,
+):
+    view = await _build_list_view(
+        interaction,
+        session_id=session_id,
+    )
+    if view is None:
+        await interaction.response.send_message(
+            "That reminder list is no longer available. Run `/reminder list` again.",
+            ephemeral=True,
+        )
+        return None
+
+    if not await view.interaction_check(interaction):
+        return None
+
+    return view
+
+
+class ReminderAddButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:add:(?P<job_id>[^:]+):(?P<user_id>\d+):(?P<ephemeral>[01])",
+):
+    def __init__(
+        self,
+        job_id: str,
+        user_id: int,
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="➕",
+                style=discord.ButtonStyle.success,
+                row=0,
+                custom_id=(
+                    f"reminder:add:{job_id}:{user_id}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.user_id = user_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderAddButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            int(match.group("user_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.ReminderEditModal import ReminderCreateModal
+
+        if not await _ensure_allowed(
+            interaction,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        ):
+            return
+
+        parent_view = await _build_output_view(
+            interaction,
+            job_id=self.job_id,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        )
+        default_channel_id = parent_view.channel_id or interaction.channel_id
+        default_destination_type = (
+            "private"
+            if parent_view.job is not None
+            and ReminderFunctions.is_private_destination(parent_view.job)
+            else "channel"
+        )
+        await interaction.response.send_modal(
+            ReminderCreateModal(
+                parent_view=parent_view,
+                default_channel_id=default_channel_id,
+                default_destination_type=default_destination_type,
+                guild=interaction.guild or parent_view.guild,
+                source_message=interaction.message,
+                response_ephemeral=self.response_ephemeral,
+                guild_id=interaction.guild_id,
+            )
+        )
+
+
+class ReminderEditButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:edit:(?P<job_id>[^:]+):(?P<user_id>\d+):(?P<ephemeral>[01])",
+):
+    def __init__(
+        self,
+        job_id: str,
+        user_id: int,
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="✏️",
+                style=discord.ButtonStyle.secondary,
+                row=0,
+                custom_id=(
+                    f"reminder:edit:{job_id}:{user_id}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.user_id = user_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderEditButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            int(match.group("user_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.ReminderEditModal import ReminderEditModal
+
+        if not await _ensure_allowed(
+            interaction,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        ):
+            return
+
+        parent_view = await _build_output_view(
+            interaction,
+            job_id=self.job_id,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        )
+        if parent_view.job is None:
+            await interaction.response.send_message(
+                "That reminder is no longer available.",
+                ephemeral=self.response_ephemeral,
+            )
+            return
+
+        channel_options = build_reminder_destination_select_options(
+            interaction.guild,
+            parent_view.job.channel_id,
+            is_private_selected=ReminderFunctions.is_private_destination(parent_view.job),
+        )
+        await interaction.response.send_modal(
+            ReminderEditModal(
+                parent_view.job,
+                channel_options=channel_options,
+                parent_view=parent_view,
+                source_message=interaction.message,
+                response_ephemeral=self.response_ephemeral,
+            )
+        )
+
+
+class ReminderPingButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:ping:(?P<job_id>[^:]+):(?P<user_id>\d+):(?P<ephemeral>[01])",
+):
+    def __init__(
+        self,
+        job_id: str,
+        user_id: int,
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="🔔",
+                style=discord.ButtonStyle.primary,
+                row=0,
+                custom_id=(
+                    f"reminder:ping:{job_id}:{user_id}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.user_id = user_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderPingButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            int(match.group("user_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.ReminderEditModal import ReminderPingModal
+
+        if not await _ensure_allowed(
+            interaction,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        ):
+            return
+
+        parent_view = await _build_output_view(
+            interaction,
+            job_id=self.job_id,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        )
+        if parent_view.job is None:
+            await interaction.response.send_message(
+                "That reminder is no longer available.",
+                ephemeral=self.response_ephemeral,
+            )
+            return
+
+        await interaction.response.send_modal(
+            ReminderPingModal(
+                guild=interaction.guild or parent_view.guild,
+                guild_id=parent_view.guild_id,
+                default_channel_id=parent_view.channel_id or interaction.channel_id,
+                response_ephemeral=self.response_ephemeral,
+                user_id=interaction.user.id,
+                job=parent_view.job,
+                parent_view=parent_view,
+                source_message=interaction.message,
+            )
+        )
+
+
+class ReminderToggleButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:toggle:(?P<job_id>[^:]+):(?P<user_id>\d+):(?P<ephemeral>[01])",
+):
+    def __init__(
+        self,
+        job_id: str,
+        user_id: int,
+        response_ephemeral: bool,
+        *,
+        paused: bool = False,
+        disabled: bool = False,
+    ) -> None:
+        emoji = "▶️" if paused else "⏸️"
+        style = discord.ButtonStyle.success if paused else discord.ButtonStyle.secondary
+        if disabled:
+            emoji = "🚫"
+            style = discord.ButtonStyle.secondary
+
+        super().__init__(
+            discord.ui.Button(
+                emoji=emoji,
+                style=style,
+                row=0,
+                custom_id=(
+                    f"reminder:toggle:{job_id}:{user_id}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.user_id = user_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderToggleButton":
+        del interaction
+        emoji = getattr(item, "emoji", None)
+        emoji_value = str(emoji) if emoji is not None else ""
+        return cls(
+            match.group("job_id"),
+            int(match.group("user_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            paused=emoji_value == "▶️",
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await _ensure_allowed(
+            interaction,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        ):
+            return
+
+        parent_view = await _build_output_view(
+            interaction,
+            job_id=self.job_id,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        )
+        if parent_view.job is None:
+            parent_view.result_message = "This reminder is no longer available."
+            parent_view.ok = False
+            await interaction.response.edit_message(**parent_view.response_payload())
+            return
+
+        await interaction.response.defer(ephemeral=self.response_ephemeral)
+
+        try:
+            if ReminderFunctions.is_paused(parent_view.job):
+                result = await asyncio.to_thread(
+                    ReminderFunctions.resume_reminder,
+                    self.job_id,
+                    parent_view.guild_id,
+                )
+                desired_message = f"Resumed reminder `{self.job_id}`."
+                no_change_message = f"Reminder `{self.job_id}` is already active."
+            else:
+                result = await asyncio.to_thread(
+                    ReminderFunctions.pause_reminder,
+                    self.job_id,
+                    parent_view.guild_id,
+                )
+                desired_message = f"Paused reminder `{self.job_id}`."
+                no_change_message = f"Reminder `{self.job_id}` is already paused."
+        except ValueError as exc:
+            await handle_interaction_error(
+                interaction,
+                ValidationError(
+                    "That reminder ID is invalid.",
+                    ephemeral=self.response_ephemeral,
+                    cause=exc,
+                ),
+                ephemeral=self.response_ephemeral,
+            )
+            return
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                exc,
+                ephemeral=self.response_ephemeral,
+            )
+            return
+
+        if result == "missing":
+            parent_view.result_message = "This reminder is no longer available."
+            parent_view.ok = False
+            await parent_view.refresh_message(
+                interaction,
+                source_message=interaction.message,
+                result_message=parent_view.result_message,
+            )
+            return
+
+        result_message = no_change_message if "already_" in result else desired_message
+        parent_view.ok = True
+        await parent_view.refresh_message(
+            interaction,
+            source_message=interaction.message,
+            result_message=result_message,
+        )
+
+
+class ReminderDeleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:delete:(?P<job_id>[^:]+):(?P<user_id>\d+):(?P<ephemeral>[01])",
+):
+    def __init__(
+        self,
+        job_id: str,
+        user_id: int,
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="🗑️",
+                style=discord.ButtonStyle.danger,
+                row=0,
+                custom_id=(
+                    f"reminder:delete:{job_id}:{user_id}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.user_id = user_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderDeleteButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            int(match.group("user_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.ReminderOutputView import ReminderDeleteConfirmModal
+
+        if not await _ensure_allowed(
+            interaction,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        ):
+            return
+
+        parent_view = await _build_output_view(
+            interaction,
+            job_id=self.job_id,
+            user_id=self.user_id,
+            response_ephemeral=self.response_ephemeral,
+        )
+        if parent_view.job is None:
+            await interaction.response.send_message(
+                "That reminder is no longer available.",
+                ephemeral=self.response_ephemeral,
+            )
+            return
+
+        await interaction.response.send_modal(ReminderDeleteConfirmModal(parent_view))
+
+
+class ReminderListItemButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:list:item:(?P<session_id>[0-9a-f]{16}):(?P<slot>[1-5])",
+):
+    def __init__(
+        self,
+        session_id: str,
+        slot: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label=str(slot),
+                style=discord.ButtonStyle.secondary,
+                row=0,
+                custom_id=f"reminder:list:item:{session_id}:{slot}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+        self.slot = slot
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderListItemButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            int(match.group("slot")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_list_view(
+            interaction,
+            session_id=self.session_id,
+        )
+        if view is None:
+            return
+
+        await view._open_reminder_details(
+            interaction,
+            view._page_item(self.slot - 1),
+        )
+
+
+class ReminderListPrevButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:list:prev:(?P<session_id>[0-9a-f]{16})",
+):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\N{BLACK LEFT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}",
+                style=discord.ButtonStyle.secondary,
+                row=1,
+                custom_id=f"reminder:list:prev:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderListPrevButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_list_view(
+            interaction,
+            session_id=self.session_id,
+        )
+        if view is None:
+            return
+
+        if view.page <= 1:
+            await interaction.response.defer(ephemeral=True)
+            return
+
+        view.page -= 1
+        view._build()
+        await view.save_session()
+        await interaction.response.edit_message(view=view, **view.payload())
+
+
+class ReminderListNextButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:list:next:(?P<session_id>[0-9a-f]{16})",
+):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\N{BLACK RIGHT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}",
+                style=discord.ButtonStyle.secondary,
+                row=1,
+                custom_id=f"reminder:list:next:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderListNextButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_list_view(
+            interaction,
+            session_id=self.session_id,
+        )
+        if view is None:
+            return
+
+        if view.page >= view.total_pages:
+            await interaction.response.defer(ephemeral=True)
+            return
+
+        view.page += 1
+        view._build()
+        await view.save_session()
+        await interaction.response.edit_message(view=view, **view.payload())
+
+
+class ReminderListAddButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:list:add:(?P<session_id>[0-9a-f]{16})",
+):
+    def __init__(self, session_id: str) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\N{HEAVY PLUS SIGN}",
+                style=discord.ButtonStyle.success,
+                row=1,
+                custom_id=f"reminder:list:add:{session_id}",
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderListAddButton":
+        del interaction, item
+        return cls(match.group("session_id"))
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_list_view(
+            interaction,
+            session_id=self.session_id,
+        )
+        if view is None:
+            return
+
+        await view.open_create_modal(
+            interaction,
+            source_message=interaction.message,
+        )
+
+
+class ReminderListOptionsButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"reminder:list:options:(?P<session_id>[0-9a-f]{16})",
+):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        active: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\N{RIGHT-POINTING MAGNIFYING GLASS}",
+                style=(
+                    discord.ButtonStyle.success
+                    if active
+                    else discord.ButtonStyle.secondary
+                ),
+                row=1,
+                custom_id=f"reminder:list:options:{session_id}",
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ReminderListOptionsButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            active=getattr(item, "style", None) == discord.ButtonStyle.success,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_list_view(
+            interaction,
+            session_id=self.session_id,
+        )
+        if view is None:
+            return
+
+        await view.open_options_modal(
+            interaction,
+            source_message=interaction.message,
+        )

--- a/views/scheduled_job_dynamic_items.py
+++ b/views/scheduled_job_dynamic_items.py
@@ -1,0 +1,442 @@
+import asyncio
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+from classes.DailyJobManager import DailyJobManager
+from embeds.DailyTaskEmbeds import DailyTaskEmbeds
+from services.discord_helpers import resolve_messageable_channel
+from services.error_reporting import ValidationError, handle_interaction_error
+
+_MODAL_SELECTS_SUPPORTED = True
+
+
+async def register_scheduled_job_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        ScheduledJobRunNowButton,
+        ScheduledJobEditButton,
+        ScheduledJobChangeChannelButton,
+        ScheduledJobDeleteButton,
+    )
+
+
+def _int_value(value: Optional[int]) -> int:
+    return int(value or 0)
+
+
+def _parse_optional_int(raw_value: str) -> Optional[int]:
+    parsed = int(raw_value)
+    return parsed or None
+
+
+def _bool_flag(value: bool) -> str:
+    return "1" if value else "0"
+
+
+def _parse_bool_flag(value: str) -> bool:
+    return str(value or "").strip() == "1"
+
+
+async def _build_view(
+    interaction: discord.Interaction,
+    *,
+    job_id: str,
+    channel_id: Optional[int],
+    guild_id: Optional[int],
+    response_ephemeral: bool,
+):
+    from views.ScheduledJobActionView import ScheduledJobActionView
+
+    view = ScheduledJobActionView(
+        job_id=job_id,
+        channel_id=channel_id,
+        guild_id=guild_id,
+        response_ephemeral=response_ephemeral,
+    )
+    view.message = interaction.message
+    await view.load_job()
+    return view
+
+
+class ScheduledJobRunNowButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=(
+        r"job:run:(?P<job_id>[^:]+):(?P<channel_id>\d+):"
+        r"(?P<guild_id>\d+):(?P<ephemeral>[01])"
+    ),
+):
+    def __init__(
+        self,
+        job_id: str,
+        channel_id: Optional[int],
+        guild_id: Optional[int],
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Run now",
+                style=discord.ButtonStyle.success,
+                custom_id=(
+                    f"job:run:{job_id}:{_int_value(channel_id)}:"
+                    f"{_int_value(guild_id)}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.channel_id = channel_id
+        self.guild_id = guild_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ScheduledJobRunNowButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            _parse_optional_int(match.group("channel_id")),
+            _parse_optional_int(match.group("guild_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=self.response_ephemeral)
+
+        try:
+            view = await _build_view(
+                interaction,
+                job_id=self.job_id,
+                channel_id=self.channel_id,
+                guild_id=self.guild_id,
+                response_ephemeral=self.response_ephemeral,
+            )
+            job = view.job
+            if job is None:
+                raise ValidationError(
+                    "That job no longer exists in this channel.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            if job.type not in {"message", "crypto", "stock"}:
+                raise ValidationError(
+                    "Run now is currently supported for message, crypto, and stock jobs.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            payload = await asyncio.to_thread(job.run)
+            if not payload:
+                raise ValidationError(
+                    "This job did not produce any output to send.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            bot = interaction.client
+            if not isinstance(bot, commands.Bot):
+                raise ValidationError(
+                    "Bot is not ready to send this job.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            channel = await resolve_messageable_channel(bot, job.channel_id)
+            if channel is None:
+                raise ValidationError(
+                    "I can't access the destination channel for this job.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            await channel.send(**payload)
+            await interaction.followup.send(
+                f"Ran job `{self.job_id}` now in <#{job.channel_id}>.",
+                ephemeral=self.response_ephemeral,
+            )
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                exc,
+                ephemeral=self.response_ephemeral,
+            )
+
+
+class ScheduledJobEditButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=(
+        r"job:edit:(?P<job_id>[^:]+):(?P<channel_id>\d+):"
+        r"(?P<guild_id>\d+):(?P<ephemeral>[01])"
+    ),
+):
+    def __init__(
+        self,
+        job_id: str,
+        channel_id: Optional[int],
+        guild_id: Optional[int],
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Edit",
+                style=discord.ButtonStyle.secondary,
+                custom_id=(
+                    f"job:edit:{job_id}:{_int_value(channel_id)}:"
+                    f"{_int_value(guild_id)}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.channel_id = channel_id
+        self.guild_id = guild_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ScheduledJobEditButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            _parse_optional_int(match.group("channel_id")),
+            _parse_optional_int(match.group("guild_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.ScheduledJobActionView import ScheduledJobEditModal
+
+        try:
+            view = await _build_view(
+                interaction,
+                job_id=self.job_id,
+                channel_id=self.channel_id,
+                guild_id=self.guild_id,
+                response_ephemeral=self.response_ephemeral,
+            )
+            job = view.job
+            if job is None:
+                raise ValidationError(
+                    "That job no longer exists in this channel.",
+                    ephemeral=self.response_ephemeral,
+                )
+            if job.type not in {"message", "crypto", "stock"}:
+                raise ValidationError(
+                    "Editing is currently supported for message, crypto, and stock jobs.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            await interaction.response.send_modal(
+                ScheduledJobEditModal(
+                    view,
+                    job,
+                    source_message=interaction.message,
+                )
+            )
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                exc,
+                ephemeral=self.response_ephemeral,
+            )
+
+
+class ScheduledJobChangeChannelButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=(
+        r"job:channel:(?P<job_id>[^:]+):(?P<channel_id>\d+):"
+        r"(?P<guild_id>\d+):(?P<ephemeral>[01])"
+    ),
+):
+    def __init__(
+        self,
+        job_id: str,
+        channel_id: Optional[int],
+        guild_id: Optional[int],
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Change Channel",
+                style=discord.ButtonStyle.primary,
+                custom_id=(
+                    f"job:channel:{job_id}:{_int_value(channel_id)}:"
+                    f"{_int_value(guild_id)}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.channel_id = channel_id
+        self.guild_id = guild_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ScheduledJobChangeChannelButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            _parse_optional_int(match.group("channel_id")),
+            _parse_optional_int(match.group("guild_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        global _MODAL_SELECTS_SUPPORTED
+
+        from views.ScheduledJobActionView import (
+            ScheduledJobChangeChannelModal,
+            _build_channel_select_options,
+        )
+
+        try:
+            view = await _build_view(
+                interaction,
+                job_id=self.job_id,
+                channel_id=self.channel_id,
+                guild_id=self.guild_id,
+                response_ephemeral=self.response_ephemeral,
+            )
+            if view.job is None:
+                raise ValidationError(
+                    "That job no longer exists in this channel.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            channel_options = _build_channel_select_options(
+                interaction,
+                view.channel_id,
+            )
+            if _MODAL_SELECTS_SUPPORTED:
+                try:
+                    await interaction.response.send_modal(
+                        ScheduledJobChangeChannelModal(
+                            view,
+                            channel_options=channel_options,
+                        )
+                    )
+                    return
+                except discord.HTTPException as exc:
+                    if exc.code == 50035 and "must be one of (4,)" in str(exc):
+                        _MODAL_SELECTS_SUPPORTED = False
+                    else:
+                        raise
+
+            await interaction.response.send_modal(ScheduledJobChangeChannelModal(view))
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                exc,
+                ephemeral=self.response_ephemeral,
+            )
+
+
+class ScheduledJobDeleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=(
+        r"job:delete:(?P<job_id>[^:]+):(?P<channel_id>\d+):"
+        r"(?P<guild_id>\d+):(?P<ephemeral>[01])"
+    ),
+):
+    def __init__(
+        self,
+        job_id: str,
+        channel_id: Optional[int],
+        guild_id: Optional[int],
+        response_ephemeral: bool,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Delete",
+                style=discord.ButtonStyle.danger,
+                custom_id=(
+                    f"job:delete:{job_id}:{_int_value(channel_id)}:"
+                    f"{_int_value(guild_id)}:{_bool_flag(response_ephemeral)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.job_id = job_id
+        self.channel_id = channel_id
+        self.guild_id = guild_id
+        self.response_ephemeral = response_ephemeral
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "ScheduledJobDeleteButton":
+        del interaction
+        return cls(
+            match.group("job_id"),
+            _parse_optional_int(match.group("channel_id")),
+            _parse_optional_int(match.group("guild_id")),
+            _parse_bool_flag(match.group("ephemeral")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer()
+        manager = DailyJobManager()
+        try:
+            view = await _build_view(
+                interaction,
+                job_id=self.job_id,
+                channel_id=self.channel_id,
+                guild_id=self.guild_id,
+                response_ephemeral=self.response_ephemeral,
+            )
+            deleted = await asyncio.to_thread(
+                manager.delete_job,
+                self.job_id,
+                self.channel_id,
+                self.guild_id,
+            )
+            if not deleted:
+                raise ValidationError(
+                    "That job no longer exists in this channel.",
+                    ephemeral=self.response_ephemeral,
+                )
+
+            view._rebuild_items(disabled=True)
+            await view.refresh_message()
+
+            await interaction.followup.send(
+                ephemeral=False,
+                **DailyTaskEmbeds.jobs_cancel_embed(
+                    f"Deleted job `{self.job_id}`.",
+                    ok=True,
+                ),
+            )
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                exc,
+                ephemeral=self.response_ephemeral,
+            )

--- a/views/stock_action_dynamic_items.py
+++ b/views/stock_action_dynamic_items.py
@@ -1,0 +1,83 @@
+import discord
+from discord.ext import commands
+
+
+async def register_stock_action_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        StockSetAlertButton,
+        StockScheduleDailyCheckButton,
+    )
+
+
+def _build_view(symbol: str):
+    from views.StockActionView import StockActionView
+
+    return StockActionView(symbol)
+
+
+class StockSetAlertButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stockaction:alert:(?P<symbol>[^:]+)",
+):
+    def __init__(self, *, symbol: str, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Set Alert",
+                style=discord.ButtonStyle.success,
+                custom_id=f"stockaction:alert:{symbol}",
+                disabled=disabled,
+            )
+        )
+        self.symbol = symbol
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockSetAlertButton":
+        del interaction
+        return cls(
+            symbol=match.group("symbol"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = _build_view(self.symbol)
+        await view.open_set_alert_modal(interaction)
+
+
+class StockScheduleDailyCheckButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stockaction:schedule:(?P<symbol>[^:]+)",
+):
+    def __init__(self, *, symbol: str, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Schedule Daily Check",
+                style=discord.ButtonStyle.secondary,
+                custom_id=f"stockaction:schedule:{symbol}",
+                disabled=disabled,
+            )
+        )
+        self.symbol = symbol
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockScheduleDailyCheckButton":
+        del interaction
+        return cls(
+            symbol=match.group("symbol"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = _build_view(self.symbol)
+        await view.open_schedule_daily_check_modal(interaction)

--- a/views/stock_alert_dynamic_items.py
+++ b/views/stock_alert_dynamic_items.py
@@ -1,0 +1,298 @@
+import asyncio
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+from classes.PriceAlertFunctions import deactivate_alert, set_alert_paused
+
+
+async def register_stock_alert_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        StockAlertEditButton,
+        StockAlertToggleButton,
+        StockAlertDeleteButton,
+    )
+
+
+def _guild_value(guild_id: Optional[int]) -> int:
+    return int(guild_id or 0)
+
+
+def _parse_guild_id(raw_value: str) -> Optional[int]:
+    parsed = int(raw_value)
+    return parsed or None
+
+
+async def _ensure_allowed(
+    interaction: discord.Interaction,
+    *,
+    user_id: int,
+) -> bool:
+    if interaction.user.id == user_id:
+        return True
+
+    await interaction.response.send_message(
+        ephemeral=True,
+        content="Only the user who opened this alert can manage it.",
+    )
+    return False
+
+
+async def _build_view(
+    interaction: discord.Interaction,
+    *,
+    alert_id: str,
+    user_id: int,
+    guild_id: Optional[int],
+):
+    from views.StockAlertActionView import StockAlertActionView
+
+    view = StockAlertActionView(
+        alert_id=alert_id,
+        user_id=user_id,
+        guild_id=guild_id,
+    )
+    view.message = interaction.message
+    await view.initialize()
+    return view
+
+
+class StockAlertEditButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=(
+        r"stockalert:edit:(?P<alert_id>[^:]+):(?P<user_id>\d+):(?P<guild_id>\d+)"
+    ),
+):
+    def __init__(
+        self,
+        alert_id: str,
+        user_id: int,
+        guild_id: Optional[int],
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Edit",
+                style=discord.ButtonStyle.primary,
+                row=0,
+                custom_id=(
+                    f"stockalert:edit:{alert_id}:{user_id}:{_guild_value(guild_id)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.alert_id = alert_id
+        self.user_id = user_id
+        self.guild_id = guild_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockAlertEditButton":
+        del interaction
+        return cls(
+            match.group("alert_id"),
+            int(match.group("user_id")),
+            _parse_guild_id(match.group("guild_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.StockAlertActionView import StockAlertEditModal
+
+        if not await _ensure_allowed(interaction, user_id=self.user_id):
+            return
+
+        view = await _build_view(
+            interaction,
+            alert_id=self.alert_id,
+            user_id=self.user_id,
+            guild_id=self.guild_id,
+        )
+        if view.alert is None:
+            await interaction.response.send_message(
+                ephemeral=True,
+                content="That alert is no longer active.",
+            )
+            return
+
+        await interaction.response.send_modal(StockAlertEditModal(view, view.alert))
+
+
+class StockAlertToggleButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=(
+        r"stockalert:toggle:(?P<alert_id>[^:]+):(?P<user_id>\d+):(?P<guild_id>\d+)"
+    ),
+):
+    def __init__(
+        self,
+        alert_id: str,
+        user_id: int,
+        guild_id: Optional[int],
+        *,
+        paused: bool = False,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Resume" if paused else "Pause",
+                style=(
+                    discord.ButtonStyle.success
+                    if paused
+                    else discord.ButtonStyle.secondary
+                ),
+                row=0,
+                custom_id=(
+                    f"stockalert:toggle:{alert_id}:{user_id}:{_guild_value(guild_id)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.alert_id = alert_id
+        self.user_id = user_id
+        self.guild_id = guild_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockAlertToggleButton":
+        del interaction
+        return cls(
+            match.group("alert_id"),
+            int(match.group("user_id")),
+            _parse_guild_id(match.group("guild_id")),
+            paused=str(getattr(item, "label", "") or "").strip().lower() == "resume",
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await _ensure_allowed(interaction, user_id=self.user_id):
+            return
+
+        view = await _build_view(
+            interaction,
+            alert_id=self.alert_id,
+            user_id=self.user_id,
+            guild_id=self.guild_id,
+        )
+
+        await interaction.response.defer(ephemeral=True)
+        if view.alert is None:
+            await interaction.followup.send(
+                ephemeral=True,
+                content="That alert is no longer active.",
+            )
+            return
+
+        currently_paused = bool(view.alert.get("paused"))
+        changed = await asyncio.to_thread(
+            set_alert_paused,
+            self.alert_id,
+            self.user_id,
+            not currently_paused,
+            asset_type="stock",
+            guild_id=self.guild_id,
+        )
+        if not changed:
+            await interaction.followup.send(
+                ephemeral=True,
+                content="That alert could not be updated.",
+            )
+            return
+
+        await view.refresh_state()
+        await view.refresh_message()
+        await interaction.followup.send(
+            ephemeral=True,
+            content="Alert resumed." if currently_paused else "Alert paused.",
+        )
+
+
+class StockAlertDeleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=(
+        r"stockalert:delete:(?P<alert_id>[^:]+):(?P<user_id>\d+):(?P<guild_id>\d+)"
+    ),
+):
+    def __init__(
+        self,
+        alert_id: str,
+        user_id: int,
+        guild_id: Optional[int],
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Delete",
+                style=discord.ButtonStyle.danger,
+                row=0,
+                custom_id=(
+                    f"stockalert:delete:{alert_id}:{user_id}:{_guild_value(guild_id)}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.alert_id = alert_id
+        self.user_id = user_id
+        self.guild_id = guild_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockAlertDeleteButton":
+        del interaction
+        return cls(
+            match.group("alert_id"),
+            int(match.group("user_id")),
+            _parse_guild_id(match.group("guild_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await _ensure_allowed(interaction, user_id=self.user_id):
+            return
+
+        view = await _build_view(
+            interaction,
+            alert_id=self.alert_id,
+            user_id=self.user_id,
+            guild_id=self.guild_id,
+        )
+
+        await interaction.response.defer(ephemeral=True)
+        deleted = await asyncio.to_thread(
+            deactivate_alert,
+            self.alert_id,
+            self.user_id,
+            "stock",
+            self.guild_id,
+        )
+        if not deleted:
+            await interaction.followup.send(
+                ephemeral=True,
+                content="That alert was not found.",
+            )
+            return
+
+        await view.refresh_state()
+        await view.refresh_message()
+        await interaction.followup.send(
+            ephemeral=True,
+            content="Alert deleted.",
+        )

--- a/views/stock_list_dynamic_items.py
+++ b/views/stock_list_dynamic_items.py
@@ -1,0 +1,324 @@
+import asyncio
+
+import discord
+from discord.ext import commands
+
+from classes.DailyJobManager import DailyJobManager
+from classes.PriceAlertFunctions import deactivate_alert
+from services.error_reporting import handle_interaction_error
+
+
+async def register_stock_list_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        StockListSelectButton,
+        StockListPrevButton,
+        StockListNextButton,
+        StockListRefreshButton,
+        StockListManageButton,
+        StockListDeleteButton,
+    )
+
+
+async def _ensure_view(
+    interaction: discord.Interaction,
+    *,
+    session_id: str,
+):
+    from views.StockListItemsView import StockListItemsView
+
+    view = await StockListItemsView.from_session(interaction, session_id)
+    if view is None:
+        await interaction.response.send_message(
+            ephemeral=True,
+            content="That stock list is no longer available. Run `/stock list` again.",
+        )
+        return None
+
+    if not await view.interaction_check(interaction):
+        return None
+    return view
+
+
+class StockListSelectButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stocklist:select:(?P<session_id>[a-f0-9]+):(?P<slot>\d+)",
+):
+    def __init__(
+        self,
+        session_id: str,
+        slot: int,
+        *,
+        disabled: bool = False,
+        selected: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label=str(slot + 1),
+                style=(
+                    discord.ButtonStyle.primary
+                    if selected
+                    else discord.ButtonStyle.secondary
+                ),
+                row=0,
+                custom_id=f"stocklist:select:{session_id}:{slot}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+        self.slot = slot
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockListSelectButton":
+        del interaction
+        style = getattr(item, "style", discord.ButtonStyle.secondary)
+        return cls(
+            match.group("session_id"),
+            int(match.group("slot")),
+            disabled=getattr(item, "disabled", False),
+            selected=style == discord.ButtonStyle.primary,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        view._select_index(self.slot)
+        await view.refresh_message(interaction)
+
+
+class StockListPrevButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stocklist:prev:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Prev",
+                style=discord.ButtonStyle.secondary,
+                row=1,
+                custom_id=f"stocklist:prev:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockListPrevButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        if view.page <= 1:
+            await interaction.response.defer(ephemeral=True)
+            return
+        view.page -= 1
+        view._select_index(0)
+        await view.refresh_message(interaction)
+
+
+class StockListNextButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stocklist:next:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Next",
+                style=discord.ButtonStyle.secondary,
+                row=1,
+                custom_id=f"stocklist:next:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockListNextButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        if view.page >= view.total_pages:
+            await interaction.response.defer(ephemeral=True)
+            return
+        view.page += 1
+        view._select_index(0)
+        await view.refresh_message(interaction)
+
+
+class StockListRefreshButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stocklist:refresh:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Refresh",
+                style=discord.ButtonStyle.secondary,
+                row=1,
+                custom_id=f"stocklist:refresh:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockListRefreshButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        await interaction.response.defer()
+        await view._reload_entries()
+        await view.refresh_message(interaction)
+
+
+class StockListManageButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stocklist:manage:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Manage",
+                style=discord.ButtonStyle.primary,
+                row=2,
+                custom_id=f"stocklist:manage:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockListManageButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        await view.send_selected_item_actions(interaction)
+
+
+class StockListDeleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"stocklist:delete:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label="Delete",
+                style=discord.ButtonStyle.danger,
+                row=2,
+                custom_id=f"stocklist:delete:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "StockListDeleteButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+
+        current = view._selected_entry()
+        if current is None:
+            await interaction.response.send_message(
+                ephemeral=True,
+                content="No item selected.",
+            )
+            return
+
+        try:
+            if str(current.get("entry_type") or "") == "schedule":
+                manager = DailyJobManager()
+                deleted = await asyncio.to_thread(
+                    manager.delete_job,
+                    str(current.get("job_id") or ""),
+                    current.get("channel_id"),
+                    current.get("guild_id"),
+                )
+                message = "Schedule deleted." if deleted else "Schedule was not found."
+            else:
+                deleted = await asyncio.to_thread(
+                    deactivate_alert,
+                    str(current.get("alert_id") or ""),
+                    view.user_id,
+                    "stock",
+                    view.guild_id,
+                )
+                message = "Alert deleted." if deleted else "Alert was not found."
+        except Exception as exc:
+            await handle_interaction_error(interaction, exc, ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        await view._reload_entries()
+        await view.refresh_message(interaction)
+        await interaction.followup.send(ephemeral=True, content=message)

--- a/views/todo_list_description_dynamic_items.py
+++ b/views/todo_list_description_dynamic_items.py
@@ -1,0 +1,457 @@
+import asyncio
+
+import discord
+from discord.ext import commands
+
+from classes.TodoFunctions import TodoFunctions
+from embeds.TodoEmbeds import TodoListItemsView
+from services.error_reporting import (
+    UserVisibleError,
+    ValidationError,
+    handle_interaction_error,
+)
+
+
+async def register_todo_list_description_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        TodoListShowButton,
+        TodoListAddButton,
+        TodoListRenameButton,
+        TodoListClearButton,
+        TodoListDeleteButton,
+    )
+
+
+async def _build_view(
+    interaction: discord.Interaction,
+    *,
+    list_id: str,
+    user_id: int,
+):
+    from views.TodoListDescriptionView import TodoListDescriptionView
+
+    todo_list = await asyncio.to_thread(
+        TodoFunctions.fetch_todo_list_by_id,
+        list_id,
+    )
+    description = ""
+    if todo_list is not None:
+        try:
+            item_count = await asyncio.to_thread(
+                TodoFunctions.count_items_on_list,
+                todo_list.get("_id"),
+            )
+        except Exception:
+            item_count = "?"
+        description = (
+            f"List: `{TodoFunctions.display_list_name(todo_list, 'List')}`\n"
+            f"Items: `{item_count}`"
+        )
+
+    view = TodoListDescriptionView(
+        title="Todo List",
+        description=description,
+        color=discord.Colour.blurple(),
+        todo_list=todo_list,
+        user_id=user_id or None,
+    )
+    view.list_id = str(list_id or "").strip()
+    view.message = interaction.message
+    return view
+
+
+async def _ensure_allowed(view, interaction: discord.Interaction) -> bool:
+    return await view.interaction_check(interaction)
+
+
+class TodoListShowButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todolist:show:(?P<list_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        list_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="📋",
+                style=discord.ButtonStyle.secondary,
+                row=0,
+                custom_id=f"todolist:show:{list_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.list_id = list_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListShowButton":
+        del interaction
+        return cls(
+            match.group("list_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _build_view(
+            interaction,
+            list_id=self.list_id,
+            user_id=self.user_id,
+        )
+        if not await _ensure_allowed(view, interaction):
+            return
+
+        todo_list = await view.refresh_todo_list()
+        if todo_list is None:
+            await handle_interaction_error(
+                interaction,
+                ValidationError("That list is no longer available.", ephemeral=True),
+            )
+            return
+
+        try:
+            items = await asyncio.to_thread(
+                TodoFunctions.list_items_on_list,
+                todo_list.get("_id"),
+                "ascending",
+            )
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                UserVisibleError(
+                    "Something went wrong while loading that list.",
+                    ephemeral=True,
+                    cause=exc,
+                ),
+            )
+            return
+
+        items_view = TodoListItemsView(
+            todo_list=todo_list,
+            items=items,
+            sort="ascending",
+            status_filter="all",
+            user_id=interaction.user.id,
+            view_scope="list",
+            guild_id=interaction.guild_id,
+        )
+        await interaction.response.send_message(
+            ephemeral=True,
+            view=items_view,
+            **items_view.payload(),
+        )
+
+
+class TodoListAddButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todolist:add:(?P<list_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        list_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="➕",
+                style=discord.ButtonStyle.success,
+                row=0,
+                custom_id=f"todolist:add:{list_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.list_id = list_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListAddButton":
+        del interaction
+        return cls(
+            match.group("list_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _build_view(
+            interaction,
+            list_id=self.list_id,
+            user_id=self.user_id,
+        )
+        if not await _ensure_allowed(view, interaction):
+            return
+
+        todo_list = await view.refresh_todo_list()
+        if todo_list is None:
+            await handle_interaction_error(
+                interaction,
+                ValidationError("That list is no longer available.", ephemeral=True),
+            )
+            return
+
+        parent_view = TodoListItemsView(
+            todo_list=todo_list,
+            items=[],
+            sort="ascending",
+            status_filter="all",
+            user_id=interaction.user.id,
+            view_scope="list",
+            guild_id=interaction.guild_id,
+        )
+        await parent_view.open_create_modal(
+            interaction,
+            source_message=None,
+        )
+
+
+class TodoListRenameButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todolist:rename:(?P<list_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        list_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="✏️",
+                style=discord.ButtonStyle.primary,
+                row=0,
+                custom_id=f"todolist:rename:{list_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.list_id = list_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListRenameButton":
+        del interaction
+        return cls(
+            match.group("list_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.TodoListDescriptionView import TodoListRenameModal
+
+        view = await _build_view(
+            interaction,
+            list_id=self.list_id,
+            user_id=self.user_id,
+        )
+        if not await _ensure_allowed(view, interaction):
+            return
+
+        todo_list = await view.refresh_todo_list()
+        if todo_list is None:
+            await handle_interaction_error(
+                interaction,
+                ValidationError("That list is no longer available.", ephemeral=True),
+            )
+            return
+
+        await interaction.response.send_modal(TodoListRenameModal(view))
+
+
+class TodoListClearButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todolist:clear:(?P<list_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        list_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="🧹",
+                style=discord.ButtonStyle.secondary,
+                row=0,
+                custom_id=f"todolist:clear:{list_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.list_id = list_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListClearButton":
+        del interaction
+        return cls(
+            match.group("list_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.TodoListDescriptionView import TodoListConfirmModal
+
+        view = await _build_view(
+            interaction,
+            list_id=self.list_id,
+            user_id=self.user_id,
+        )
+        if not await _ensure_allowed(view, interaction):
+            return
+
+        todo_list = await view.refresh_todo_list()
+        if todo_list is None:
+            await handle_interaction_error(
+                interaction,
+                ValidationError("That list is no longer available.", ephemeral=True),
+            )
+            return
+
+        try:
+            item_count = await asyncio.to_thread(
+                TodoFunctions.count_items_on_list,
+                todo_list.get("_id"),
+            )
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                UserVisibleError(
+                    "Something went wrong while preparing that confirmation.",
+                    ephemeral=True,
+                    cause=exc,
+                ),
+            )
+            return
+
+        description = view._format_confirmation_description(
+            action_text="This will remove every item from this list.",
+            list_name=TodoFunctions.display_list_name(todo_list, "List"),
+            item_count=item_count,
+        )
+        await interaction.response.send_modal(
+            TodoListConfirmModal(
+                title="Clear Todo List",
+                description=description,
+                on_confirm=view._run_clear_list,
+            )
+        )
+
+
+class TodoListDeleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todolist:delete:(?P<list_id>[^:]+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        list_id: str,
+        user_id: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="🗑️",
+                style=discord.ButtonStyle.danger,
+                row=0,
+                custom_id=f"todolist:delete:{list_id}:{user_id}",
+                disabled=disabled,
+            )
+        )
+        self.list_id = list_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListDeleteButton":
+        del interaction
+        return cls(
+            match.group("list_id"),
+            int(match.group("user_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.TodoListDescriptionView import TodoListConfirmModal
+
+        view = await _build_view(
+            interaction,
+            list_id=self.list_id,
+            user_id=self.user_id,
+        )
+        if not await _ensure_allowed(view, interaction):
+            return
+
+        todo_list = await view.refresh_todo_list()
+        if todo_list is None:
+            await handle_interaction_error(
+                interaction,
+                ValidationError("That list is no longer available.", ephemeral=True),
+            )
+            return
+
+        list_name = TodoFunctions.display_list_name(todo_list, "List")
+        try:
+            item_count = await asyncio.to_thread(
+                TodoFunctions.count_items_on_list,
+                todo_list.get("_id"),
+            )
+        except Exception as exc:
+            await handle_interaction_error(
+                interaction,
+                UserVisibleError(
+                    "Something went wrong while preparing that confirmation.",
+                    ephemeral=True,
+                    cause=exc,
+                ),
+            )
+            return
+
+        description = view._format_confirmation_description(
+            action_text="This will permanently delete this custom list.",
+            list_name=list_name,
+            item_count=item_count,
+        )
+        await interaction.response.send_modal(
+            TodoListConfirmModal(
+                title="Delete Todo List",
+                description=description,
+                on_confirm=view._run_delete_list,
+            )
+        )

--- a/views/todo_list_description_dynamic_items.py
+++ b/views/todo_list_description_dynamic_items.py
@@ -145,6 +145,7 @@ class TodoListShowButton(
             view_scope="list",
             guild_id=interaction.guild_id,
         )
+        await items_view.ensure_session()
         await interaction.response.send_message(
             ephemeral=True,
             view=items_view,

--- a/views/todo_list_directory_dynamic_items.py
+++ b/views/todo_list_directory_dynamic_items.py
@@ -1,0 +1,253 @@
+import discord
+from discord.ext import commands
+
+
+async def register_todo_list_directory_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        TodoDirectoryOpenButton,
+        TodoDirectoryPrevButton,
+        TodoDirectoryNextButton,
+        TodoDirectorySortButton,
+        TodoDirectoryCreateButton,
+    )
+
+
+async def _ensure_view(
+    interaction: discord.Interaction,
+    *,
+    session_id: str,
+):
+    from views.TodoListDirectoryView import TodoListDirectoryView
+
+    view = await TodoListDirectoryView.from_session(interaction, session_id)
+    if view is None:
+        await interaction.response.send_message(
+            "That todo list directory is no longer available. Run `/todo list directory` again.",
+            ephemeral=True,
+        )
+        return None
+
+    if not await view.interaction_check(interaction):
+        return None
+    return view
+
+
+class TodoDirectoryOpenButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"tododir:open:(?P<session_id>[a-f0-9]+):(?P<slot>\d+)",
+):
+    def __init__(
+        self,
+        session_id: str,
+        slot: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label=str(slot + 1),
+                style=discord.ButtonStyle.secondary,
+                row=0,
+                custom_id=f"tododir:open:{session_id}:{slot}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+        self.slot = slot
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoDirectoryOpenButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            int(match.group("slot")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        await view.open_page_entry(interaction, self.slot)
+
+
+class TodoDirectoryPrevButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"tododir:prev:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=discord.ButtonStyle.secondary,
+                emoji="◀️",
+                row=1,
+                custom_id=f"tododir:prev:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoDirectoryPrevButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        if view.page <= 1:
+            await interaction.response.defer()
+            return
+        view.page -= 1
+        view._build()
+        await interaction.response.edit_message(view=view, **view.payload())
+        await view.save_session()
+
+
+class TodoDirectoryNextButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"tododir:next:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=discord.ButtonStyle.secondary,
+                emoji="▶️",
+                row=1,
+                custom_id=f"tododir:next:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoDirectoryNextButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        if view.page >= view.total_pages:
+            await interaction.response.defer()
+            return
+        view.page += 1
+        view._build()
+        await interaction.response.edit_message(view=view, **view.payload())
+        await view.save_session()
+
+
+class TodoDirectorySortButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"tododir:sort:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        descending: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=(
+                    discord.ButtonStyle.primary
+                    if descending
+                    else discord.ButtonStyle.secondary
+                ),
+                emoji="🔽" if descending else "🔼",
+                row=1,
+                custom_id=f"tododir:sort:{session_id}",
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoDirectorySortButton":
+        del interaction
+        emoji = str(getattr(item, "emoji", "") or "")
+        return cls(
+            match.group("session_id"),
+            descending=emoji == "🔽",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        view.message = interaction.message
+        view.sort_direction = (
+            "descending" if view.sort_direction == "ascending" else "ascending"
+        )
+        view._sort_entries()
+        view.page = 1
+        view._build()
+        await interaction.response.edit_message(view=view, **view.payload())
+        await view.save_session()
+
+
+class TodoDirectoryCreateButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"tododir:create:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=discord.ButtonStyle.success,
+                emoji="➕",
+                row=1,
+                custom_id=f"tododir:create:{session_id}",
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoDirectoryCreateButton":
+        del interaction, item
+        return cls(match.group("session_id"))
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.TodoListDirectoryView import TodoListDirectoryCreateModal
+
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        view.message = interaction.message
+        await interaction.response.send_modal(TodoListDirectoryCreateModal(view))

--- a/views/todo_list_items_dynamic_items.py
+++ b/views/todo_list_items_dynamic_items.py
@@ -1,0 +1,257 @@
+import discord
+from discord.ext import commands
+
+
+async def register_todo_list_items_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        TodoListItemInfoButton,
+        TodoListItemsPrevButton,
+        TodoListItemsNextButton,
+        TodoListItemsAddButton,
+        TodoListItemsOptionsButton,
+    )
+
+
+async def _ensure_view(
+    interaction: discord.Interaction,
+    *,
+    session_id: str,
+):
+    from embeds.TodoEmbeds import TodoListItemsView
+
+    view = await TodoListItemsView.from_session(interaction, session_id)
+    if view is None:
+        await interaction.response.send_message(
+            ephemeral=True,
+            content="That todo list is no longer available. Run `/todo list view` again.",
+        )
+        return None
+
+    if view.user_id is not None and interaction.user.id != view.user_id:
+        await interaction.response.send_message(
+            ephemeral=True,
+            content="Only the user who opened this list can manage it.",
+        )
+        return None
+
+    return view
+
+
+class TodoListItemInfoButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todoitems:info:(?P<session_id>[a-f0-9]+):(?P<slot>\d+)",
+):
+    def __init__(
+        self,
+        session_id: str,
+        slot: int,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                label=str(slot + 1),
+                style=discord.ButtonStyle.secondary,
+                row=0,
+                custom_id=f"todoitems:info:{session_id}:{slot}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+        self.slot = slot
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListItemInfoButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            int(match.group("slot")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        await view._open_item_details(interaction, view._page_item(self.slot))
+
+
+class TodoListItemsPrevButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todoitems:prev:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=discord.ButtonStyle.secondary,
+                emoji="\u25c0\ufe0f",
+                row=1,
+                custom_id=f"todoitems:prev:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListItemsPrevButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        if view.page <= 1:
+            await interaction.response.defer(ephemeral=True)
+            return
+        view.page -= 1
+        await view._safe_refresh_message(interaction)
+
+
+class TodoListItemsNextButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todoitems:next:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(self, session_id: str, *, disabled: bool = False) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=discord.ButtonStyle.secondary,
+                emoji="\u25b6\ufe0f",
+                row=1,
+                custom_id=f"todoitems:next:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListItemsNextButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        if view.page >= view.total_pages:
+            await interaction.response.defer(ephemeral=True)
+            return
+        view.page += 1
+        await view._safe_refresh_message(interaction)
+
+
+class TodoListItemsAddButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todoitems:add:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=discord.ButtonStyle.success,
+                emoji="\u2795",
+                row=1,
+                custom_id=f"todoitems:add:{session_id}",
+                disabled=disabled,
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListItemsAddButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        await view.open_create_modal(
+            interaction,
+            source_message=interaction.message,
+        )
+
+
+class TodoListItemsOptionsButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"todoitems:options:(?P<session_id>[a-f0-9]+)",
+):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        active: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                style=(
+                    discord.ButtonStyle.success
+                    if active
+                    else discord.ButtonStyle.secondary
+                ),
+                emoji="\U0001F50E",
+                row=1,
+                custom_id=f"todoitems:options:{session_id}",
+            )
+        )
+        self.session_id = session_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TodoListItemsOptionsButton":
+        del interaction
+        return cls(
+            match.group("session_id"),
+            active=getattr(item, "style", None) == discord.ButtonStyle.success,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _ensure_view(interaction, session_id=self.session_id)
+        if view is None:
+            return
+        await view.open_options_modal(
+            interaction,
+            source_message=interaction.message,
+        )

--- a/views/toggl_dynamic_items.py
+++ b/views/toggl_dynamic_items.py
@@ -1,0 +1,378 @@
+import asyncio
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+
+async def register_toggl_dynamic_items(bot: commands.Bot) -> None:
+    bot.add_dynamic_items(
+        TogglPlayPauseButton,
+        TogglStopButton,
+        TogglEditButton,
+        TogglDeleteButton,
+        TogglListTimersButton,
+    )
+
+
+def _decode_optional_int(value: str) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed or None
+
+
+async def _build_view(
+    interaction: discord.Interaction,
+    *,
+    guild_id: Optional[int],
+    user_id: int,
+    workspace_id: Optional[int],
+    time_entry_id: Optional[int],
+    is_active_hint: bool,
+):
+    from views.TogglTimerView import TogglTimerView
+
+    if interaction.user.id != user_id:
+        await interaction.response.send_message(
+            ephemeral=True,
+            content="Only the user who opened this Toggl timer can manage it.",
+        )
+        return None
+
+    view = await TogglTimerView.from_dynamic_reference(
+        guild_id=guild_id,
+        user_id=user_id,
+        workspace_id=workspace_id,
+        time_entry_id=time_entry_id,
+        is_active_hint=is_active_hint,
+    )
+    if view is None:
+        await interaction.response.send_message(
+            ephemeral=True,
+            content="That Toggl timer is no longer available.",
+        )
+        return None
+
+    return view
+
+
+class TogglPlayPauseButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"toggl:toggle:(?P<guild_id>\d+):(?P<user_id>\d+):(?P<workspace_id>\d+):(?P<time_entry_id>\d+):(?P<active>[01])",
+):
+    def __init__(
+        self,
+        *,
+        guild_id: int,
+        user_id: int,
+        workspace_id: int,
+        time_entry_id: int,
+        is_active: bool,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\u23f8\ufe0f" if is_active else "\u25b6\ufe0f",
+                style=(
+                    discord.ButtonStyle.secondary
+                    if is_active
+                    else discord.ButtonStyle.success
+                ),
+                row=0,
+                custom_id=(
+                    f"toggl:toggle:{guild_id}:{user_id}:{workspace_id}:{time_entry_id}:"
+                    f"{1 if is_active else 0}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.workspace_id = workspace_id
+        self.time_entry_id = time_entry_id
+        self.is_active = is_active
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TogglPlayPauseButton":
+        del interaction
+        return cls(
+            guild_id=int(match.group("guild_id")),
+            user_id=int(match.group("user_id")),
+            workspace_id=int(match.group("workspace_id")),
+            time_entry_id=int(match.group("time_entry_id")),
+            is_active=match.group("active") == "1",
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _build_view(
+            interaction,
+            guild_id=_decode_optional_int(str(self.guild_id)),
+            user_id=self.user_id,
+            workspace_id=_decode_optional_int(str(self.workspace_id)),
+            time_entry_id=_decode_optional_int(str(self.time_entry_id)),
+            is_active_hint=self.is_active,
+        )
+        if view is None:
+            return
+        await view._handle_play_pause(interaction)
+
+
+class TogglStopButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"toggl:stop:(?P<guild_id>\d+):(?P<user_id>\d+):(?P<workspace_id>\d+):(?P<time_entry_id>\d+):(?P<active>[01])",
+):
+    def __init__(
+        self,
+        *,
+        guild_id: int,
+        user_id: int,
+        workspace_id: int,
+        time_entry_id: int,
+        is_active: bool,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\u23f9\ufe0f",
+                style=discord.ButtonStyle.danger,
+                row=0,
+                custom_id=(
+                    f"toggl:stop:{guild_id}:{user_id}:{workspace_id}:{time_entry_id}:"
+                    f"{1 if is_active else 0}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.workspace_id = workspace_id
+        self.time_entry_id = time_entry_id
+        self.is_active = is_active
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TogglStopButton":
+        del interaction
+        return cls(
+            guild_id=int(match.group("guild_id")),
+            user_id=int(match.group("user_id")),
+            workspace_id=int(match.group("workspace_id")),
+            time_entry_id=int(match.group("time_entry_id")),
+            is_active=match.group("active") == "1",
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _build_view(
+            interaction,
+            guild_id=_decode_optional_int(str(self.guild_id)),
+            user_id=self.user_id,
+            workspace_id=_decode_optional_int(str(self.workspace_id)),
+            time_entry_id=_decode_optional_int(str(self.time_entry_id)),
+            is_active_hint=self.is_active,
+        )
+        if view is None:
+            return
+        await view._handle_stop(interaction)
+
+
+class TogglEditButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"toggl:edit:(?P<guild_id>\d+):(?P<user_id>\d+):(?P<workspace_id>\d+):(?P<time_entry_id>\d+)",
+):
+    def __init__(
+        self,
+        *,
+        guild_id: int,
+        user_id: int,
+        workspace_id: int,
+        time_entry_id: int,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\u270f\ufe0f",
+                style=discord.ButtonStyle.primary,
+                row=0,
+                custom_id=f"toggl:edit:{guild_id}:{user_id}:{workspace_id}:{time_entry_id}",
+                disabled=disabled,
+            )
+        )
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.workspace_id = workspace_id
+        self.time_entry_id = time_entry_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TogglEditButton":
+        del interaction
+        return cls(
+            guild_id=int(match.group("guild_id")),
+            user_id=int(match.group("user_id")),
+            workspace_id=int(match.group("workspace_id")),
+            time_entry_id=int(match.group("time_entry_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _build_view(
+            interaction,
+            guild_id=_decode_optional_int(str(self.guild_id)),
+            user_id=self.user_id,
+            workspace_id=_decode_optional_int(str(self.workspace_id)),
+            time_entry_id=_decode_optional_int(str(self.time_entry_id)),
+            is_active_hint=False,
+        )
+        if view is None:
+            return
+        await view._handle_edit(interaction)
+
+
+class TogglDeleteButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"toggl:delete:(?P<guild_id>\d+):(?P<user_id>\d+):(?P<workspace_id>\d+):(?P<time_entry_id>\d+)",
+):
+    def __init__(
+        self,
+        *,
+        guild_id: int,
+        user_id: int,
+        workspace_id: int,
+        time_entry_id: int,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\U0001f5d1\ufe0f",
+                style=discord.ButtonStyle.danger,
+                row=0,
+                custom_id=(
+                    f"toggl:delete:{guild_id}:{user_id}:{workspace_id}:{time_entry_id}"
+                ),
+                disabled=disabled,
+            )
+        )
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.workspace_id = workspace_id
+        self.time_entry_id = time_entry_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TogglDeleteButton":
+        del interaction
+        return cls(
+            guild_id=int(match.group("guild_id")),
+            user_id=int(match.group("user_id")),
+            workspace_id=int(match.group("workspace_id")),
+            time_entry_id=int(match.group("time_entry_id")),
+            disabled=getattr(item, "disabled", False),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = await _build_view(
+            interaction,
+            guild_id=_decode_optional_int(str(self.guild_id)),
+            user_id=self.user_id,
+            workspace_id=_decode_optional_int(str(self.workspace_id)),
+            time_entry_id=_decode_optional_int(str(self.time_entry_id)),
+            is_active_hint=False,
+        )
+        if view is None:
+            return
+        await view._handle_delete(interaction)
+
+
+class TogglListTimersButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"toggl:list:(?P<guild_id>\d+):(?P<user_id>\d+)",
+):
+    def __init__(
+        self,
+        *,
+        guild_id: int,
+        user_id: int,
+    ) -> None:
+        super().__init__(
+            discord.ui.Button(
+                emoji="\U0001f4cb",
+                style=discord.ButtonStyle.secondary,
+                row=0,
+                custom_id=f"toggl:list:{guild_id}:{user_id}",
+            )
+        )
+        self.guild_id = guild_id
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Item,
+        match,
+        /,
+    ) -> "TogglListTimersButton":
+        del interaction, item
+        return cls(
+            guild_id=int(match.group("guild_id")),
+            user_id=int(match.group("user_id")),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                ephemeral=True,
+                content="Only the user who opened this Toggl timer can manage it.",
+            )
+            return
+
+        from embeds.TogglEmbeds import TogglEmbeds
+        from views.TogglTimerHistoryView import TogglTimerHistoryView
+
+        try:
+            payload = await asyncio.to_thread(
+                TogglEmbeds.timerhistory_embed,
+                5,
+                _decode_optional_int(str(self.guild_id)),
+                self.user_id,
+            )
+        except Exception:
+            await interaction.response.send_message(
+                ephemeral=True,
+                content="I couldn't load your recent Toggl timers right now. Please try again.",
+            )
+            return
+
+        toggl_timer_history_view = payload.pop("_toggl_timer_history_view", None)
+        if toggl_timer_history_view is not None:
+            payload["view"] = TogglTimerHistoryView(**toggl_timer_history_view)
+
+        await interaction.response.send_message(
+            ephemeral=True,
+            **payload,
+        )


### PR DESCRIPTION
- on a bot restart, the references that buttons in Views to access context were removed
- now references persist across restarts